### PR TITLE
Fixed: Make title less clickable by accident on mobile #256

### DIFF
--- a/app/resources/views/partials/main-header.blade.php
+++ b/app/resources/views/partials/main-header.blade.php
@@ -1,10 +1,14 @@
 <header class="main-header">
 
     <!-- Logo -->
-    <a href="{{ url('') }}" class="logo">
-        <span class="logo-mini">O<b>D</b></span>
-        <span class="logo-lg">Open<b>Dominion</b></span>
-    </a>
+    <div style="background-color: #367FA9;">
+        <div style="margin: 0 100px;">
+            <a href="{{ url('') }}" class="logo">
+                <span class="logo-mini">O<b>D</b></span>
+                <span class="logo-lg">Open<b>Dominion</b></span>
+            </a>
+        </div>
+    </div>
 
     <!-- Header Navbar -->
     <nav class="navbar navbar-static-top" role="navigation">


### PR DESCRIPTION
## Description
I wrapped the logo link in two divs. One to give it a margin, and the other to correct the resulting background color change.

## Motivation and Context
https://github.com/WaveHack/OpenDominion/issues/256

## How Has This Been Tested?
I have only tested this fix on a browser emulating mobile screens. Please let me know if further testing is necessary.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
