### PR TITLE
Icekin raw wizard ratio is set in the offense calculator

### DIFF
--- a/app/resources/views/pages/dominion/calculations.blade.php
+++ b/app/resources/views/pages/dominion/calculations.blade.php
@@ -589,6 +589,7 @@
                                                     class="form-control text-center"
                                                     placeholder="3"
                                                     min="0"
+                                                    value="{{ ($targetDominion !== null && $targetDominion->race_id == $race->id && $targetInfoOps->has('clear_sight')) && (array_get($targetInfoOps['clear_sight']->data, "military_wizards") !== null) ? ((array_get($targetInfoOps['clear_sight']->data, "military_wizards") + array_get($targetInfoOps['clear_sight']->data, "military_archmages") * 2) / array_get($targetInfoOps['clear_sight']->data, "land")) : null }}"
                                                     disabled />
                                         </div>
                                     @endif


### PR DESCRIPTION

## Description
When using the calculator to calculate an Icekins offense, use the actual WPA instead of defaulting to 3 when advisors are shared.

## Motivation and Context
Convenience.

## How Has This Been Tested?
It has been lightly tested by creating a test icekin dominion and adjusting wizards in that dominion. I did not know how to get ops on another dominion in the test environment. So i did not verify it's not leaking information from non-realmies.

## Screenshots (if appropriate):
<img width="816" alt="Screenshot 2021-04-15 at 19 27 56" src="https://user-images.githubusercontent.com/2063622/114912968-e9961000-9e20-11eb-84a7-8f9b63bc71af.png">

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
