### PR TITLE
Add guided new-player onboarding

### DIFF
--- a/app/resources/js/app.js
+++ b/app/resources/js/app.js
@@ -10,6 +10,7 @@ import './sidebar.js';
 import './momentum.js';
 import './bootstrap-app.js';
 import './color-mode.js';
+import './new-player-tour.js';
 
 $(() => {
     // Ticker

--- a/app/resources/js/new-player-tour.js
+++ b/app/resources/js/new-player-tour.js
@@ -1,0 +1,174 @@
+'use strict';
+
+const tour = document.querySelector('[data-new-player-tour]');
+
+if (tour) {
+    const key = tour.dataset.tourTarget;
+    const pageTarget = document.querySelector(`[data-onboarding-target="${key}"]`);
+    const navTarget = document.querySelector(`[data-onboarding-nav="${tour.dataset.tourNav}"]`);
+    const collapseButton = tour.querySelector('[data-tour-collapse]');
+    const dragHandle = tour.querySelector('[data-tour-drag-handle]');
+    const showPageButton = tour.querySelector('[data-tour-show-page]');
+    const resumeButton = document.querySelector('[data-tour-resume]');
+    const desktop = window.matchMedia('(min-width: 768px)');
+    const positionStorageKey = `new-player-tour-position:${key}`;
+    const clamp = (value, maximum) => Math.min(Math.max(16, value), Math.max(16, maximum));
+    let dragPosition = null;
+    let drag = null;
+    let positionFrame = null;
+
+    try {
+        dragPosition = JSON.parse(sessionStorage.getItem(positionStorageKey));
+    } catch {
+        dragPosition = null;
+    }
+    if (!Number.isFinite(dragPosition?.left) || !Number.isFinite(dragPosition?.top)) {
+        dragPosition = null;
+    }
+
+    pageTarget?.classList.add('new-player-tour-target');
+    navTarget?.classList.add('new-player-tour-nav-target');
+
+    const position = () => {
+        if (!desktop.matches) {
+            tour.style.removeProperty('--tour-top');
+            tour.style.removeProperty('--tour-left');
+            return;
+        }
+
+        if (dragPosition) {
+            const left = clamp(dragPosition.left, window.innerWidth - tour.offsetWidth - 16);
+            const top = clamp(dragPosition.top, window.innerHeight - tour.offsetHeight - 16);
+            dragPosition = { left, top };
+            tour.style.setProperty('--tour-top', `${top}px`);
+            tour.style.setProperty('--tour-left', `${left}px`);
+            return;
+        }
+
+        if (!pageTarget) {
+            return;
+        }
+
+        const target = pageTarget.getBoundingClientRect();
+        const width = Math.min(360, window.innerWidth - 32);
+        const right = target.right + 16;
+        const hasRightSpace = right + width <= window.innerWidth - 16;
+        const hasLeftSpace = target.left - width - 16 >= 16;
+        let left = hasRightSpace ? right : hasLeftSpace ? target.left - width - 16 : 16;
+        let top = clamp(target.top, window.innerHeight - tour.offsetHeight - 16);
+        const above = target.top - tour.offsetHeight - 16;
+        if (!hasRightSpace && !hasLeftSpace && above >= 16) {
+            left = clamp(target.left, window.innerWidth - width - 16);
+            top = above;
+        }
+
+        tour.style.setProperty('--tour-top', `${top}px`);
+        tour.style.setProperty('--tour-left', `${left}px`);
+    };
+
+    const schedulePosition = () => {
+        if (positionFrame !== null) {
+            return;
+        }
+
+        positionFrame = requestAnimationFrame(() => {
+            positionFrame = null;
+            position();
+        });
+    };
+
+    const moveDrag = event => {
+        if (!drag) {
+            return;
+        }
+
+        dragPosition = {
+            left: drag.left + event.clientX - drag.x,
+            top: drag.top + event.clientY - drag.y,
+        };
+        schedulePosition();
+    };
+
+    const finishDrag = () => {
+        if (!drag) {
+            return;
+        }
+
+        drag = null;
+        tour.classList.remove('new-player-tour--dragging');
+        try {
+            sessionStorage.setItem(positionStorageKey, JSON.stringify(dragPosition));
+        } catch {
+            // Position persistence is optional; dragging still works without it.
+        }
+    };
+
+    dragHandle?.addEventListener('mousedown', event => {
+        if (!desktop.matches || event.button !== 0) {
+            return;
+        }
+
+        event.preventDefault();
+        const bounds = tour.getBoundingClientRect();
+        drag = { x: event.clientX, y: event.clientY, left: bounds.left, top: bounds.top };
+        tour.classList.add('new-player-tour--dragging');
+    });
+    window.addEventListener('mousemove', moveDrag);
+    window.addEventListener('mouseup', finishDrag);
+
+    const collapse = ({ keepPageHighlight = false, focusResume = true } = {}) => {
+        tour.hidden = true;
+        resumeButton.hidden = false;
+        if (!keepPageHighlight) {
+            pageTarget?.classList.remove('new-player-tour-target');
+        }
+        navTarget?.classList.remove('new-player-tour-nav-target');
+        if (focusResume) {
+            resumeButton.focus();
+        }
+    };
+
+    const showPage = () => {
+        collapse({ keepPageHighlight: true, focusResume: false });
+        if (!pageTarget) {
+            resumeButton.focus();
+            return;
+        }
+
+        pageTarget.scrollIntoView({
+            behavior: window.matchMedia('(prefers-reduced-motion: reduce)').matches ? 'auto' : 'smooth',
+            block: 'start',
+        });
+        if (!pageTarget.hasAttribute('tabindex')) {
+            pageTarget.setAttribute('tabindex', '-1');
+            pageTarget.dataset.tourTemporaryTabindex = 'true';
+        }
+        pageTarget.focus({ preventScroll: true });
+    };
+
+    const resume = () => {
+        tour.hidden = false;
+        resumeButton.hidden = true;
+        pageTarget?.classList.add('new-player-tour-target');
+        navTarget?.classList.add('new-player-tour-nav-target');
+        if (pageTarget?.dataset.tourTemporaryTabindex === 'true') {
+            pageTarget.removeAttribute('tabindex');
+            delete pageTarget.dataset.tourTemporaryTabindex;
+        }
+        schedulePosition();
+        collapseButton.focus();
+    };
+
+    collapseButton.addEventListener('click', collapse);
+    showPageButton.addEventListener('click', showPage);
+    resumeButton.addEventListener('click', resume);
+    window.addEventListener('resize', schedulePosition, { passive: true });
+    window.addEventListener('scroll', schedulePosition, { passive: true });
+    document.addEventListener('keydown', event => {
+        if (event.key === 'Escape' && !tour.hidden) {
+            collapse();
+        }
+    });
+
+    schedulePosition();
+}

--- a/app/resources/sass/app.scss
+++ b/app/resources/sass/app.scss
@@ -123,6 +123,287 @@ a {
   .badge ~ .badge { margin-left: 0; }
 }
 
+.new-player-tour {
+  position: fixed;
+  z-index: 1055;
+  top: var(--tour-top, 5rem);
+  left: var(--tour-left, auto);
+  right: 1rem;
+  width: min(22.5rem, calc(100vw - 2rem));
+  padding: 1rem;
+  border: 1px solid color-mix(in srgb, var(--bs-primary) 45%, var(--bs-border-color));
+  border-radius: 0.65rem;
+  background: var(--bs-body-bg);
+  box-shadow: 0 0.75rem 2rem rgba(0, 0, 0, 0.28);
+  animation: new-player-tour-enter 180ms ease-out;
+
+  h2 {
+    margin: 0.8rem 1.5rem 0.45rem 0;
+    font-size: 1.05rem;
+  }
+
+  p {
+    margin-bottom: 1rem;
+    color: var(--bs-secondary-color);
+    font-size: 0.9rem;
+    line-height: 1.5;
+  }
+}
+
+.new-player-tour-progress,
+.new-player-tour-actions {
+  display: flex;
+  align-items: center;
+}
+
+.new-player-tour-progress {
+  justify-content: space-between;
+  color: var(--bs-primary);
+  font-size: 0.68rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+}
+
+@media (min-width: 768px) {
+  .new-player-tour-progress {
+    cursor: grab;
+    user-select: none;
+  }
+
+  .new-player-tour--dragging .new-player-tour-progress {
+    cursor: grabbing;
+  }
+}
+
+.new-player-tour-meter {
+  height: 2px;
+  margin-top: 0.4rem;
+  overflow: hidden;
+  background: var(--bs-border-color);
+
+  span {
+    display: block;
+    height: 100%;
+    background: var(--bs-primary);
+  }
+}
+
+.new-player-tour-actions form {
+  margin: 0;
+}
+
+.new-player-tour-details {
+  margin: -0.25rem 0 0.85rem;
+  border-top: 1px solid var(--bs-border-color);
+  border-bottom: 1px solid var(--bs-border-color);
+
+  summary {
+    display: grid;
+    grid-template-columns: 1fr auto auto;
+    align-items: center;
+    gap: 1rem;
+    padding: 0.55rem 0;
+    color: var(--bs-secondary-color);
+    font-size: 0.78rem;
+    cursor: pointer;
+
+    &::after {
+      color: var(--bs-primary);
+      content: '\203A';
+      font-size: 1rem;
+      line-height: 1;
+      transition: transform 150ms ease-out;
+    }
+  }
+
+  ol {
+    margin: 0;
+    padding: 0 0 0.65rem;
+    list-style: none;
+  }
+}
+
+.new-player-tour-objective {
+  display: grid;
+  grid-template-columns: 1rem 1fr;
+  gap: 0.45rem;
+  margin: -0.15rem 0 0.85rem;
+  padding: 0.6rem 0.7rem;
+  border-left: 3px solid var(--bs-warning);
+  border-radius: 0.25rem;
+  background: color-mix(in srgb, var(--bs-warning) 10%, transparent);
+  color: var(--bs-secondary-color);
+  font-size: 0.78rem;
+
+  strong {
+    display: block;
+    color: var(--bs-body-color);
+    font-size: 0.72rem;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+  }
+}
+
+.new-player-tour-objective--complete {
+  border-left-color: var(--bs-success);
+  background: color-mix(in srgb, var(--bs-success) 9%, transparent);
+
+  > i,
+  strong {
+    color: var(--bs-success);
+  }
+}
+
+.new-player-tour-details[open] summary::after {
+  transform: rotate(90deg);
+}
+
+.new-player-tour-details-count {
+  white-space: nowrap;
+}
+
+.new-player-tour-progress-item {
+  display: grid;
+  grid-template-columns: 1rem 1fr auto;
+  gap: 0.35rem;
+  align-items: center;
+  padding: 0.18rem 0;
+  color: var(--bs-secondary-color);
+  font-size: 0.75rem;
+
+  small {
+    font-size: 0.72rem;
+  }
+}
+
+.new-player-tour-progress-item--completed {
+  color: var(--bs-success);
+}
+
+.new-player-tour-progress-item--ready {
+  color: var(--bs-success);
+  font-weight: 600;
+}
+
+.new-player-tour-progress-item--current {
+  color: var(--bs-body-color);
+  font-weight: 600;
+}
+
+.new-player-tour-progress-item--locked {
+  opacity: 0.72;
+}
+
+.new-player-tour-show-page {
+  display: none;
+}
+
+.new-player-tour-collapse {
+  position: absolute;
+  top: 2.35rem;
+  right: 0.7rem;
+  border: 0;
+  background: transparent;
+  color: var(--bs-secondary-color);
+}
+
+.new-player-tour-resume {
+  position: fixed;
+  z-index: 1055;
+  right: 1rem;
+  bottom: 1rem;
+  padding: 0.65rem 0.85rem;
+  border: 1px solid var(--bs-primary);
+  border-radius: 999px;
+  background: var(--bs-body-bg);
+  box-shadow: 0 0.4rem 1rem rgba(0, 0, 0, 0.2);
+  color: var(--bs-body-color);
+  font-size: 0.8rem;
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.new-player-tour-resume--paused {
+  border-color: var(--bs-border-color);
+  color: var(--bs-secondary-color);
+}
+
+.new-player-tour-resume-form {
+  margin: 0;
+}
+
+.new-player-tour-resume--complete {
+  border-color: var(--bs-success);
+  color: var(--bs-success);
+}
+
+.new-player-tour-collapse:focus-visible,
+.new-player-tour-resume:focus-visible {
+  outline: 0.2rem solid color-mix(in srgb, var(--bs-primary) 45%, transparent);
+  outline-offset: 0.15rem;
+}
+
+.new-player-tour-target {
+  position: relative;
+  z-index: 1045;
+  outline: 2px solid var(--bs-primary);
+  outline-offset: 3px;
+}
+
+.new-player-tour-nav-target {
+  box-shadow: inset 3px 0 0 var(--bs-primary);
+  animation: new-player-tour-pulse 1.8s ease-in-out infinite;
+}
+
+@keyframes new-player-tour-enter {
+  from { opacity: 0; transform: translateY(4px); }
+}
+
+@keyframes new-player-tour-pulse {
+  50% { background-color: color-mix(in srgb, var(--bs-primary) 20%, transparent); }
+}
+
+@media (max-width: 767.98px) {
+  .new-player-tour {
+    top: auto;
+    right: 0.75rem;
+    bottom: calc(4.5rem + env(safe-area-inset-bottom));
+    left: 0.75rem;
+    width: auto;
+    max-height: min(25rem, 46dvh);
+    padding-bottom: 0;
+    overflow-y: auto;
+    overscroll-behavior: contain;
+  }
+
+  .new-player-tour-actions {
+    position: sticky;
+    bottom: 0;
+    flex-wrap: wrap;
+    gap: 0.4rem;
+    margin: 0 -1rem;
+    padding: 0.65rem 1rem 0.85rem;
+    border-top: 1px solid var(--bs-border-color);
+    background: var(--bs-body-bg);
+  }
+
+  .new-player-tour-show-page {
+    display: inline-block;
+  }
+
+  .new-player-tour-resume {
+    bottom: calc(4.5rem + env(safe-area-inset-bottom));
+    max-width: calc(100vw - 2rem);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .new-player-tour,
+  .new-player-tour-nav-target {
+    animation: none;
+  }
+}
+
 .table-responsive td,
 .table-responsive th {
   white-space: nowrap;

--- a/app/resources/views/layouts/master.blade.php
+++ b/app/resources/views/layouts/master.blade.php
@@ -79,6 +79,8 @@
 
 @include('partials.mobile-bottom-nav')
 
+@include('partials.new-player-tour')
+
 @include('partials.scripts')
 
 </body>

--- a/app/resources/views/pages/dominion/advisors/production.blade.php
+++ b/app/resources/views/pages/dominion/advisors/production.blade.php
@@ -16,7 +16,7 @@
     <div class="row">
 
         <div class="col-sm-12 col-md-9">
-            <div class="card card-primary">
+            <div class="card card-primary" data-onboarding-target="advisors">
                 <div class="card-header">
                     <span class="card-title"><i class="fa fa-industry"></i> {{ $pageHeader }}</span>
                 </div>

--- a/app/resources/views/pages/dominion/bonuses.blade.php
+++ b/app/resources/views/pages/dominion/bonuses.blade.php
@@ -6,7 +6,7 @@
     <div class="row">
 
         <div class="col-sm-12 col-md-9">
-            <div class="card card-primary">
+            <div class="card card-primary" data-onboarding-target="daily-bonus">
                 <div class="card-header">
                     <span class="card-title"><i class="fa fa-gift"></i> Daily bonuses</span>
                 </div>
@@ -34,7 +34,7 @@
                 </div>
             </div>
 
-            <div class="card">
+            <div class="card" data-onboarding-target="discord-community">
                 <div class="card-body">
                     <p>While you're here, consider supporting the project in one (or more) of the following ways:</p>
 

--- a/app/resources/views/pages/dominion/construction.blade.php
+++ b/app/resources/views/pages/dominion/construction.blade.php
@@ -12,7 +12,7 @@
     <div class="row">
 
         <div class="col-sm-12 col-md-9">
-            <div class="card card-primary">
+            <div class="card card-primary" data-onboarding-target="construction">
                 <div class="card-header">
                     <span class="card-title"><i class="fa fa-home"></i> Construct Buildings</span>
                 </div>

--- a/app/resources/views/pages/dominion/explore.blade.php
+++ b/app/resources/views/pages/dominion/explore.blade.php
@@ -10,7 +10,7 @@
     <div class="row">
 
         <div class="col-sm-12 col-md-9">
-            <div class="card card-primary">
+            <div class="card card-primary" data-onboarding-target="explore">
                 <div class="card-header">
                     <span class="card-title"><i class="ra ra-telescope"></i> Explore Land</span>
                 </div>

--- a/app/resources/views/pages/dominion/magic.blade.php
+++ b/app/resources/views/pages/dominion/magic.blade.php
@@ -241,7 +241,7 @@
                 </div>
 
                 <div class="col-md-12">
-                    <div class="card card-primary">
+                    <div class="card card-primary" data-onboarding-target="self-spells">
                         <div class="card-header">
                             <span class="card-title"><i class="ra ra-fairy-wand"></i> Self Spells</span>
                         </div>

--- a/app/resources/views/pages/dominion/military.blade.php
+++ b/app/resources/views/pages/dominion/military.blade.php
@@ -6,7 +6,7 @@
     <div class="row">
 
         <div class="col-sm-12 col-md-9">
-            <div class="card card-primary">
+            <div class="card card-primary" data-onboarding-target="military">
                 <div class="card-header">
                     <span class="card-title"><i class="ra ra-sword"></i> Military</span>
                 </div>

--- a/app/resources/views/pages/dominion/protection/buildings.blade.php
+++ b/app/resources/views/pages/dominion/protection/buildings.blade.php
@@ -8,11 +8,11 @@
             $defaultBuildings = $buildingHelper->getDefaultBuildings($selectedDominion->protection_type == 'quick');
         @endphp
         <div class="col-sm-12 col-md-9">
-            <div class="card card-primary">
+            <div class="card card-primary" data-onboarding-target="starting-buildings">
                 <div class="card-header">
                     <span class="card-title"><i class="fa fa-home"></i> Select Starting Buildings</span>
                 </div>
-                <form action="{{ route('dominion.protection.buildings') }}" method="post" role="form">
+                <form id="starting-buildings-form" action="{{ route('dominion.protection.buildings') }}" method="post" role="form">
                     @csrf
                     <div class="card-body">
                         <div class="row">
@@ -140,7 +140,7 @@
 @push('inline-scripts')
     <script type="text/javascript">
         (function ($) {
-            var submitButtonElement = $('button[type=submit]');
+            var submitButtonElement = $('#starting-buildings-form button[type=submit]');
             var totalBuildingsElement = $('#total_buildings');
             var totalLandElement = $('#total_land');
 

--- a/app/resources/views/pages/dominion/rankings.blade.php
+++ b/app/resources/views/pages/dominion/rankings.blade.php
@@ -6,7 +6,7 @@
     <div class="row">
 
         <div class="col-sm-12 col-md-9">
-            <div class="card card-primary">
+            <div class="card card-primary" data-onboarding-target="rankings">
                 <div class="card-header">
                     <span class="card-title">
                         <i class="fa fa-trophy"></i> Rankings

--- a/app/resources/views/pages/dominion/realm.blade.php
+++ b/app/resources/views/pages/dominion/realm.blade.php
@@ -5,7 +5,7 @@
 @section('content')
     <div class="row">
         <div class="col-sm-12 col-md-9">
-            <div class="card card-primary">
+            <div class="card card-primary" data-onboarding-target="realm">
                 <div class="card-header">
                     <span class="card-title"><i class="ra ra-circle-of-circles"></i> {{ $realm->name }} (#{{ $realm->number }})</span>
                 </div>

--- a/app/resources/views/pages/dominion/restart.blade.php
+++ b/app/resources/views/pages/dominion/restart.blade.php
@@ -6,7 +6,7 @@
     <div class="row">
 
         <div class="col-sm-12 col-md-6">
-            <div class="card card-primary">
+            <div class="card card-primary" data-onboarding-target="quick-start">
                 <div class="card-header">
                     <span class="card-title"><i class="fa fa-undo"></i> Restart</span>
                 </div>

--- a/app/resources/views/pages/dominion/status.blade.php
+++ b/app/resources/views/pages/dominion/status.blade.php
@@ -6,7 +6,7 @@
     <div class="row">
 
         <div class="col-sm-12 col-md-9">
-            <div class="card card-primary">
+            <div class="card card-primary" data-onboarding-target="status">
                 <div class="card-header">
                     <span class="card-title"><i class="fa fa-bar-chart"></i> The Dominion of {{ $selectedDominion->name }} (#{{ $selectedDominion->realm->number }})</span>
                 </div>

--- a/app/resources/views/pages/settings.blade.php
+++ b/app/resources/views/pages/settings.blade.php
@@ -91,6 +91,17 @@
                                     </div>
                                 </div>
                             </div>
+
+                            {{-- New-player guide --}}
+                            <div class="mb-3 row">
+                                <label class="col-sm-3 col-form-label">Game Guide</label>
+                                <div class="col-sm-9">
+                                    <p class="form-text mt-0">Restart the guided introduction to core pages, verified protection quests, and game concepts. Your sidebar will reveal features as you progress, and you can skip at any time.</p>
+                                    <button class="btn btn-outline-primary" type="submit" form="restart-new-player-tour">
+                                        <i class="fa fa-compass"></i> Restart Game Guide
+                                    </button>
+                                </div>
+                            </div>
                         </div>
                         <div class="col-md-6">
 
@@ -246,6 +257,10 @@
                 <button type="submit" class="btn btn-primary">Update Settings</button>
             </div>
         </div>
+    </form>
+
+    <form id="restart-new-player-tour" action="{{ route('new-player-tour.restart') }}" method="post">
+        @csrf
     </form>
 
     @if (isset($selectedDominion))

--- a/app/resources/views/partials/main-sidebar.blade.php
+++ b/app/resources/views/partials/main-sidebar.blade.php
@@ -7,6 +7,7 @@
     <div class="sidebar-wrapper">
         @php
             $hiddenLinks = $selectedDominion->settings['hidden_links'] ?? [];
+            $navigationUnlocked = static fn (int $requiredStage): bool => $onboardingStage === null || $onboardingStage >= $requiredStage;
         @endphp
 
         @if (isset($selectedDominion))
@@ -24,22 +25,25 @@
 
                     <li class="nav-header">GENERAL</li>
                     <li class="nav-item {{ Route::is('dominion.status') ? 'active' : null }}">
-                        <a href="{{ route('dominion.status') }}" class="nav-link {{ Route::is('dominion.status') ? 'active' : null }}">
+                        <a href="{{ route('dominion.status') }}" class="nav-link {{ Route::is('dominion.status') ? 'active' : null }}" data-onboarding-nav="status">
                             <i class="nav-icon fa fa-bar-chart fa-fw"></i> <p>Status</p>
                         </a>
                     </li>
+                    @if ($navigationUnlocked(1))
                     <li class="nav-item {{ Route::is('dominion.advisors.*') ? 'active' : null }}">
-                        <a href="{{ route('dominion.advisors') }}" class="nav-link {{ Route::is('dominion.advisors.*') ? 'active' : null }}">
+                        <a href="{{ route('dominion.advisors') }}" class="nav-link {{ Route::is('dominion.advisors.*') ? 'active' : null }}" data-onboarding-nav="advisors">
                             <i class="nav-icon ra ra-classical-knowledge ra-fw"></i> <p>Advisors</p>
                         </a>
                     </li>
+                    @endif
+                    @if ($navigationUnlocked(2))
                     <li class="nav-item {{ Route::is('dominion.bonuses.actions') ? 'active' : null }}">
                         <a href="{{ route('dominion.bonuses.actions') }}" class="nav-link {{ Route::is('dominion.bonuses.actions') ? 'active' : null }}">
                             <i class="nav-icon ra ra-robot-arm ra-fw"></i> <p>Automation</p>
                         </a>
                     </li>
                     <li class="nav-item {{ Route::is('dominion.bonuses') ? 'active' : null }}">
-                        <a href="{{ route('dominion.bonuses') }}" class="nav-link {{ Route::is('dominion.bonuses') ? 'active' : null }}">
+                        <a href="{{ route('dominion.bonuses') }}" class="nav-link {{ Route::is('dominion.bonuses') ? 'active' : null }}" data-onboarding-nav="daily_bonus">
                             <i class="nav-icon fa fa-gift fa-fw"></i>
                             <p>Daily Bonus
                                 @if (!$selectedDominion->daily_land)
@@ -81,16 +85,20 @@
                             </a>
                         @endif
                     </li>
+                    @endif
 
+                    @if ($navigationUnlocked(3))
                     <li class="nav-header">DOMINION</li>
                     <li class="nav-item {{ Route::is('dominion.explore') ? 'active' : null }} {{ in_array('explore_land', $hiddenLinks) ? 'd-none' : null }}">
-                        <a href="{{ route('dominion.explore') }}" class="nav-link {{ Route::is('dominion.explore') ? 'active' : null }}">
+                        <a href="{{ route('dominion.explore') }}" class="nav-link {{ Route::is('dominion.explore') ? 'active' : null }}" data-onboarding-nav="explore">
                             <i class="nav-icon ra ra-telescope ra-fw"></i> <p>Explore Land</p>
                         </a>
                     </li>
+                    @endif
+                    @if ($navigationUnlocked(4))
                     @if ($selectedDominion->isBuildingPhase())
                         <li class="nav-item {{ Route::is('dominion.protection.buildings') ? 'active' : null }}">
-                            <a href="{{ route('dominion.protection.buildings') }}" class="nav-link {{ Route::is('dominion.protection.buildings') ? 'active' : null }}">
+                            <a href="{{ route('dominion.protection.buildings') }}" class="nav-link {{ Route::is('dominion.protection.buildings') ? 'active' : null }}" data-onboarding-nav="construction">
                                 <i class="nav-icon fa fa-home fa-fw"></i>
                                 <p>Construct Buildings
                                     @if ($barrenLand > 0)
@@ -101,7 +109,7 @@
                         </li>
                     @else
                         <li class="nav-item {{ Route::is('dominion.construct') ? 'active' : null }}">
-                            <a href="{{ route('dominion.construct') }}" class="nav-link {{ Route::is('dominion.construct') ? 'active' : null }}">
+                            <a href="{{ route('dominion.construct') }}" class="nav-link {{ Route::is('dominion.construct') ? 'active' : null }}" data-onboarding-nav="construction">
                                 <i class="nav-icon fa fa-home fa-fw"></i>
                                 <p>Construct Buildings
                                     @if ($barrenLand > 0)
@@ -116,6 +124,8 @@
                             <i class="nav-icon fa fa-refresh fa-fw"></i> <p>Re-zone Land</p>
                         </a>
                     </li>
+                    @endif
+                    @if ($navigationUnlocked(5))
                     <li class="nav-item {{ Route::is('dominion.improvements') ? 'active' : null }}">
                         <a href="{{ route('dominion.improvements') }}" class="nav-link {{ Route::is('dominion.improvements') ? 'active' : null }}">
                             <i class="nav-icon ra ra-castle ra-fw"></i> <p>Improvements</p>
@@ -187,20 +197,24 @@
                             <i class="nav-icon ra ra-scroll-quill ra-fw"></i> <p>Journal</p>
                         </a>
                     </li>
+                    @endif
 
+                    @if ($navigationUnlocked(5))
                     <li class="nav-header">OPERATIONS</li>
                     <li class="nav-item {{ Route::is('dominion.military') ? 'active' : null }}">
-                        <a href="{{ route('dominion.military') }}" class="nav-link {{ Route::is('dominion.military') ? 'active' : null }}">
+                        <a href="{{ route('dominion.military') }}" class="nav-link {{ Route::is('dominion.military') ? 'active' : null }}" data-onboarding-nav="military">
                             <i class="nav-icon ra ra-sword ra-fw"></i> <p>Military</p>
                         </a>
                     </li>
+                    @endif
+                    @if ($navigationUnlocked(6))
                     <li class="nav-item {{ Route::is('dominion.invade') ? 'active' : null }} {{ in_array('invade', $hiddenLinks) ? 'd-none' : null }}">
                         <a href="{{ route('dominion.invade') }}" class="nav-link {{ Route::is('dominion.invade') ? 'active' : null }}">
                             <i class="nav-icon ra ra-crossed-swords ra-fw"></i> <p>Invade</p>
                         </a>
                     </li>
                     <li class="nav-item {{ Route::is('dominion.magic') ? 'active' : null }}">
-                        <a href="{{ route('dominion.magic') }}" class="nav-link {{ Route::is('dominion.magic') ? 'active' : null }}">
+                        <a href="{{ route('dominion.magic') }}" class="nav-link {{ Route::is('dominion.magic') ? 'active' : null }}" data-onboarding-nav="magic">
                             <i class="nav-icon ra ra-fairy-wand ra-fw"></i>
                             <p>Magic
                                 @if ($activeSelfSpells > 0)
@@ -268,13 +282,17 @@
                             <i class="nav-icon fa fa-calculator fa-fw"></i> <p>Calculators</p>
                         </a>
                     </li>
+                    @endif
 
+                    @if ($navigationUnlocked(7))
                     <li class="nav-header">RELATIONS</li>
                     <li class="nav-item {{ Route::is('dominion.realm') ? 'active' : null }}">
-                        <a href="{{ route('dominion.realm') }}" class="nav-link {{ Route::is('dominion.realm') ? 'active' : null }}">
+                        <a href="{{ route('dominion.realm') }}" class="nav-link {{ Route::is('dominion.realm') ? 'active' : null }}" data-onboarding-nav="realm">
                             <i class="nav-icon ra ra-circle-of-circles ra-fw"></i> <p>Realms</p>
                         </a>
                     </li>
+                    @endif
+                    @if ($navigationUnlocked(8))
                     <li class="nav-item {{ Route::is('dominion.world') ? 'active' : null }} {{ in_array('world', $hiddenLinks) ? 'd-none' : null }}">
                         <a href="{{ route('dominion.world') }}" class="nav-link {{ Route::is('dominion.world') ? 'active' : null }}">
                             <i class="nav-icon fa fa-globe fa-fw"></i> <p>The World</p>
@@ -311,7 +329,7 @@
                         </a>
                     </li>
                     <li class="nav-item {{ Route::is('dominion.rankings') ? 'active' : null }} {{ in_array('rankings', $hiddenLinks) ? 'd-none' : null }}">
-                        <a href="{{ route('dominion.rankings') }}" class="nav-link {{ Route::is('dominion.rankings') ? 'active' : null }}">
+                        <a href="{{ route('dominion.rankings') }}" class="nav-link {{ Route::is('dominion.rankings') ? 'active' : null }}" data-onboarding-nav="rankings">
                             <i class="nav-icon fa fa-trophy fa-fw"></i> <p>Rankings</p>
                         </a>
                     </li>
@@ -335,7 +353,9 @@
                             </p>
                         </a>
                     </li>
+                    @endif
 
+                    @if ($onboardingStage === null)
                     <li class="nav-header">USER</li>
                     <li class="nav-item {{ Route::is('message-board*') ? 'active' : null }}">
                         <a href="{{ route('message-board') }}" class="nav-link {{ Route::is('message-board*') ? 'active' : null }}">
@@ -353,6 +373,7 @@
                                 <i class="nav-icon ra ra-dragon ra-fw"></i> <p>Debug Page</p>
                             </a>
                         </li>
+                    @endif
                     @endif
 
                 @else

--- a/app/resources/views/partials/mobile-bottom-nav.blade.php
+++ b/app/resources/views/partials/mobile-bottom-nav.blade.php
@@ -1,20 +1,20 @@
 @if (isset($selectedDominion))
 @php
     $navLinks = [
-        'advisors'     => ['icon' => 'ra ra-classical-knowledge', 'route' => 'dominion.advisors',   'active' => 'dominion.advisors*'],
-        'explore'      => ['icon' => 'ra ra-telescope',           'route' => 'dominion.explore',     'active' => 'dominion.explore'],
-        'construct'    => ['icon' => 'fa fa-home',                'route' => null,                   'active' => null],
-        'improvements' => ['icon' => 'ra ra-castle',              'route' => 'dominion.improvements','active' => 'dominion.improvements'],
-        'military'     => ['icon' => 'ra ra-sword',               'route' => 'dominion.military',    'active' => 'dominion.military'],
-        'town_crier'   => ['icon' => 'fa fa-newspaper-o',         'route' => 'dominion.town-crier',  'active' => 'dominion.town-crier'],
-        'bounty_board' => ['icon' => 'ra ra-hanging-sign',        'route' => 'dominion.bounty-board','active' => 'dominion.bounty-board'],
-        'magic'        => ['icon' => 'ra ra-fairy-wand',          'route' => 'dominion.magic',       'active' => 'dominion.magic'],
-        'espionage'    => ['icon' => 'fa fa-user-secret',         'route' => 'dominion.espionage',   'active' => 'dominion.espionage'],
-        'bank'         => ['icon' => 'fa fa-money',               'route' => 'dominion.bank',        'active' => 'dominion.bank'],
-        'realm'        => ['icon' => 'ra ra-circle-of-circles',   'route' => 'dominion.realm',       'active' => 'dominion.realm'],
-        'search'       => ['icon' => 'fa fa-search',              'route' => 'dominion.search',      'active' => 'dominion.search'],
-        'calculate'    => ['icon' => 'fa fa-calculator',           'route' => null,                   'active' => 'dominion.calculations.military'],
-        'sidebar'      => ['icon' => 'fa fa-bars',                'route' => null,                   'active' => null],
+        'advisors'     => ['icon' => 'ra ra-classical-knowledge', 'route' => 'dominion.advisors',   'active' => 'dominion.advisors*',            'stage' => 1],
+        'explore'      => ['icon' => 'ra ra-telescope',           'route' => 'dominion.explore',     'active' => 'dominion.explore',              'stage' => 3],
+        'construct'    => ['icon' => 'fa fa-home',                'route' => null,                   'active' => null,                            'stage' => 4],
+        'improvements' => ['icon' => 'ra ra-castle',              'route' => 'dominion.improvements','active' => 'dominion.improvements',         'stage' => 5],
+        'military'     => ['icon' => 'ra ra-sword',               'route' => 'dominion.military',    'active' => 'dominion.military',             'stage' => 5],
+        'town_crier'   => ['icon' => 'fa fa-newspaper-o',         'route' => 'dominion.town-crier',  'active' => 'dominion.town-crier',           'stage' => 8],
+        'bounty_board' => ['icon' => 'ra ra-hanging-sign',        'route' => 'dominion.bounty-board','active' => 'dominion.bounty-board',          'stage' => 6],
+        'magic'        => ['icon' => 'ra ra-fairy-wand',          'route' => 'dominion.magic',       'active' => 'dominion.magic',                'stage' => 6],
+        'espionage'    => ['icon' => 'fa fa-user-secret',         'route' => 'dominion.espionage',   'active' => 'dominion.espionage',            'stage' => 6],
+        'bank'         => ['icon' => 'fa fa-money',               'route' => 'dominion.bank',        'active' => 'dominion.bank',                 'stage' => 5],
+        'realm'        => ['icon' => 'ra ra-circle-of-circles',   'route' => 'dominion.realm',       'active' => 'dominion.realm',                'stage' => 7],
+        'search'       => ['icon' => 'fa fa-search',              'route' => 'dominion.search',      'active' => 'dominion.search',               'stage' => 8],
+        'calculate'    => ['icon' => 'fa fa-calculator',          'route' => null,                   'active' => 'dominion.calculations.military','stage' => 6],
+        'sidebar'      => ['icon' => 'fa fa-bars',                'route' => null,                   'active' => null,                            'stage' => 0],
     ];
 
     $defaults = ['advisors', 'explore', 'construct', 'improvements', 'military', 'town_crier', 'sidebar'];
@@ -24,6 +24,8 @@
     @foreach ($slots as $key)
         @if ($key === '' || !isset($navLinks[$key]))
             {{-- empty slot --}}
+        @elseif ($onboardingStage !== null && $onboardingStage < $navLinks[$key]['stage'])
+            {{-- This destination has not been introduced yet. --}}
         @elseif ($key === 'sidebar')
             <a class="mobile-bottom-nav-item" href="#" data-lte-toggle="sidebar" role="button">
                 <i class="{{ $navLinks[$key]['icon'] }}"></i>

--- a/app/resources/views/partials/new-player-tour.blade.php
+++ b/app/resources/views/partials/new-player-tour.blade.php
@@ -1,0 +1,104 @@
+@if ($newPlayerTour)
+    @if ($newPlayerTour['is_current_page'])
+        <section
+            class="new-player-tour"
+            data-new-player-tour
+            data-tour-target="{{ $newPlayerTour['target'] }}"
+            data-tour-nav="{{ $newPlayerTour['nav'] }}"
+            aria-labelledby="new-player-tour-title"
+        >
+            <div class="new-player-tour-progress" data-tour-drag-handle title="Drag field guide" aria-label="Guide progress: step {{ $newPlayerTour['number'] }} of {{ $newPlayerTour['total'] }}. Drag to move on desktop.">
+                <span>{{ $newPlayerTour['phase_label'] }}</span>
+                <span>{{ $newPlayerTour['number'] }} / {{ $newPlayerTour['total'] }}</span>
+            </div>
+            <div class="new-player-tour-meter" aria-hidden="true">
+                <span style="width: {{ $newPlayerTour['progress_percent'] }}%"></span>
+            </div>
+            <h2 id="new-player-tour-title">{{ $newPlayerTour['title'] }}</h2>
+            <p>{{ $newPlayerTour['body'] }}</p>
+            @if ($newPlayerTour['quest'])
+                <div class="new-player-tour-objective {{ $newPlayerTour['satisfied'] ? 'new-player-tour-objective--complete' : null }}" role="status">
+                    <i class="fa {{ $newPlayerTour['satisfied'] ? 'fa-check-circle' : 'fa-circle-o' }}" aria-hidden="true"></i>
+                    <span>
+                        <strong>{{ $newPlayerTour['satisfied'] ? 'Quest complete' : 'Your objective' }}</strong>
+                        {{ $newPlayerTour['satisfied'] ? 'The game recorded this action. Continue when ready.' : $newPlayerTour['objective'] }}
+                    </span>
+                </div>
+            @endif
+            <details class="new-player-tour-details">
+                <summary>
+                    <span>View guide progress</span>
+                    <span class="new-player-tour-details-count">{{ collect($newPlayerTour['progress_items'])->where('state', 'completed')->count() }} complete</span>
+                </summary>
+                <ol>
+                    @foreach ($newPlayerTour['progress_items'] as $item)
+                        <li class="new-player-tour-progress-item new-player-tour-progress-item--{{ $item['state'] }}">
+                            <i class="fa {{ in_array($item['state'], ['completed', 'ready']) ? 'fa-check' : ($item['state'] === 'locked' ? 'fa-lock' : 'fa-circle-o') }}" aria-hidden="true"></i>
+                            <span>{{ $item['label'] }}</span>
+                            <small>{{ ucfirst($item['state']) }}</small>
+                        </li>
+                    @endforeach
+                </ol>
+            </details>
+            <div class="new-player-tour-actions">
+                <div class="d-flex align-items-center gap-1">
+                    <button type="button" class="btn btn-outline-primary btn-sm new-player-tour-show-page" data-tour-show-page>
+                        <i class="fa fa-crosshairs me-1" aria-hidden="true"></i> Show page
+                    </button>
+                    @if ($newPlayerTour['action_url'])
+                        <a href="{{ $newPlayerTour['action_url'] }}" class="btn btn-outline-primary btn-sm" @if ($newPlayerTour['action_external']) target="_blank" rel="noopener" @endif>
+                            <i class="fa {{ $newPlayerTour['action_external'] ? 'fa-external-link' : 'fa-refresh' }} me-1" aria-hidden="true"></i>
+                            {{ $newPlayerTour['action_label'] }}
+                        </a>
+                    @endif
+                    <form action="{{ route('new-player-tour.skip') }}" method="post">
+                        @csrf
+                        <button type="submit" class="btn btn-link btn-sm">Skip guide</button>
+                    </form>
+                </div>
+                <div class="d-flex gap-2 ms-auto">
+                    @if ($newPlayerTour['number'] > 1)
+                        <form action="{{ route('new-player-tour.back') }}" method="post">
+                            @csrf
+                            <button type="submit" class="btn btn-outline-secondary btn-sm">Previous</button>
+                        </form>
+                    @endif
+                    @if (!$newPlayerTour['paused'] && (!$newPlayerTour['quest'] || $newPlayerTour['satisfied']))
+                        <form action="{{ route('new-player-tour.advance') }}" method="post">
+                            @csrf
+                            <button type="submit" class="btn btn-primary btn-sm">
+                                {{ $newPlayerTour['number'] === $newPlayerTour['total'] ? 'Finish guide' : ($newPlayerTour['quest'] ? 'Continue quest' : 'Continue') }}
+                                <i class="fa fa-arrow-right ms-1" aria-hidden="true"></i>
+                            </button>
+                        </form>
+                    @endif
+                </div>
+            </div>
+            <button type="button" class="new-player-tour-collapse" data-tour-collapse aria-label="Collapse game guide" title="Collapse game guide">
+                <i class="fa fa-chevron-down" aria-hidden="true"></i>
+            </button>
+        </section>
+        <button type="button" class="new-player-tour-resume" data-tour-resume hidden>
+            <i class="fa fa-compass" aria-hidden="true"></i>
+            Resume guide: {{ $newPlayerTour['label'] }}
+        </button>
+    @elseif ($newPlayerTour['paused'])
+        <div class="new-player-tour-resume new-player-tour-resume--paused" role="status">
+            <i class="fa fa-hourglass-half" aria-hidden="true"></i>
+            Guide resumes after protection
+        </div>
+    @elseif ($newPlayerTour['quest'] && $newPlayerTour['satisfied'])
+        <form class="new-player-tour-resume-form" action="{{ route('new-player-tour.advance') }}" method="post">
+            @csrf
+            <button class="new-player-tour-resume new-player-tour-resume--complete" type="submit">
+                <i class="fa fa-check-circle" aria-hidden="true"></i>
+                Quest complete: continue guide
+            </button>
+        </form>
+    @else
+        <a class="new-player-tour-resume" href="{{ $newPlayerTour['url'] }}">
+            <i class="fa fa-compass" aria-hidden="true"></i>
+            Continue guide: {{ $newPlayerTour['label'] }}
+        </a>
+    @endif
+@endif

--- a/app/resources/views/partials/protection-indicator.blade.php
+++ b/app/resources/views/partials/protection-indicator.blade.php
@@ -20,7 +20,7 @@
                     Protection Hour {{ $selectedDominion->protection_ticks - $selectedDominion->protection_ticks_remaining + 1 }}
                 @endif
             </div>
-            <div class="col-2 text-center text-sm-end">
+            <div class="col-2 text-center text-sm-end" data-onboarding-target="protection-confirm">
                 @if (!$selectedDominion->protection_finished)
                     <a href="{{ route('dominion.misc.tick') }}" class="btn btn-sm btn-primary py-0 disable-after-click">
                         @if ($selectedDominion->protection_ticks_remaining == 0)

--- a/app/resources/views/partials/resources-overview.blade.php
+++ b/app/resources/views/partials/resources-overview.blade.php
@@ -27,7 +27,7 @@
             $config = $selectedDominion->settings['resources_overview'];
         }
     @endphp
-    <div class="card">
+    <div class="card" data-onboarding-target="resources-overview">
         <div class="card-header">
             <span class="card-title"><i class="fa fa-bar-chart"></i> Overview - {{ $selectedDominion->name }}</span>
             <a href="{{ route('dominion.misc.settings') }}" title="Resource Display Settings" data-bs-toggle="tooltip">

--- a/app/routes/web.php
+++ b/app/routes/web.php
@@ -58,6 +58,12 @@ $router->group(['middleware' => 'auth'], static function (Router $router) {
     $router->get('settings')->uses('SettingsController@getIndex')->name('settings');
     $router->post('settings')->uses('SettingsController@postIndex');
 
+    // New-player guide
+    $router->post('new-player-tour/advance')->uses('NewPlayerTourController@postAdvance')->name('new-player-tour.advance');
+    $router->post('new-player-tour/back')->uses('NewPlayerTourController@postBack')->name('new-player-tour.back');
+    $router->post('new-player-tour/skip')->uses('NewPlayerTourController@postSkip')->name('new-player-tour.skip');
+    $router->post('new-player-tour/restart')->uses('NewPlayerTourController@postRestart')->name('new-player-tour.restart');
+
     // Round Register
     $router->get('round/{round}/register')->uses('RoundController@getRegister')->name('round.register');
     $router->post('round/{round}/register')->uses('RoundController@postRegister');

--- a/docs/claude/FRONTEND.md
+++ b/docs/claude/FRONTEND.md
@@ -199,6 +199,46 @@ The light theme has a special dark sidebar/header defined directly in `app.scss`
 | `partials/notification-nav.blade.php` | Notifications dropdown |
 | `partials/auth-user-nav.blade.php` | User account dropdown |
 
+### New-player game guide
+
+Newly registered accounts begin an optional progressive guide. Its state is
+stored in the existing user `settings` JSON under `new_player_tour`; existing
+accounts without that key retain the complete navigation. The guide may be
+skipped at any time or restarted by any user from account settings.
+
+`NewPlayerTourService` owns the ordered stops, copy, routes, navigation stages,
+and persistence rules. `partials/new-player-tour.blade.php` renders the anchored
+field note, while `new-player-tour.js` positions it and supports collapse/resume.
+Desktop and mobile navigation both use `onboardingStage` so locked destinations
+are not leaked through shortcuts. Page cards and sidebar links expose stable
+`data-onboarding-target` and `data-onboarding-nav` attributes; preserve those
+identifiers when changing templates.
+
+The sequence is phase-aware. Status through Magic form the foundation chapter;
+Quick Start setup precedes Advisors and Starting Buildings, Community appears
+after Daily Bonus, a separate Construction quest follows Explore, and Realms and
+Rankings are active-play lessons. Explore and Construction each require both the
+page action and the following Quick Start protection advance. When the foundation
+is completed under protection, progress remains on Realm but the presentation
+becomes a non-blocking chapter checkpoint and all navigation is revealed. The
+active chapter resumes automatically only after
+`ProtectionService::isUnderProtection()` is false and the round reports that realm
+assignment is complete. Keep route eligibility, sidebar stage, and mobile shortcut
+visibility derived from this same service.
+
+Quick Start, Starting Buildings, Daily Bonus, Explore, Construction, Military,
+and Magic are verified quests. `NewPlayerTourService` checks existing dominion
+history/state for the quick restart, starting buildings, both daily claims,
+exploration, protection advances, training, and a self-spell before its advance
+endpoint will accept the step. Keep these predicates server-side and grounded in
+`HistoryService` events; never replace them with browser-only flags.
+Informational lessons remain manually advanced. The Quick Start quest applies
+only to newly registered users; restarting the guide later must not require
+restarting an established dominion. The Discord stop provides a direct invite
+action using the configured community URL (with the official repository invite
+as fallback), while the protection checkpoint links to the existing Restart or
+Rename page for players who want a clean slate.
+
 ## Adding a New Theme
 
 1. Create `app/resources/sass/_theme-<name>.scss` with a `[data-color-scheme="<name>"]` block

--- a/src/Http/Controllers/NewPlayerTourController.php
+++ b/src/Http/Controllers/NewPlayerTourController.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace OpenDominion\Http\Controllers;
+
+use Auth;
+use Illuminate\Http\RedirectResponse;
+use OpenDominion\Models\Dominion;
+use OpenDominion\Services\Dominion\SelectorService;
+use OpenDominion\Services\NewPlayerTourService;
+
+class NewPlayerTourController extends AbstractController
+{
+    public function postAdvance(NewPlayerTourService $tour, SelectorService $selector): RedirectResponse
+    {
+        $dominion = $this->selectedDominion($selector);
+        $currentUrl = $tour->getCurrentStepUrl(Auth::user(), $dominion);
+        $advanced = $tour->advance(Auth::user(), $dominion);
+        $nextUrl = $tour->getCurrentStepUrl(Auth::user(), $dominion);
+
+        if (!$advanced) {
+            session()->flash('alert-warning', 'Complete the current field-guide objective before continuing.');
+        }
+
+        return $nextUrl !== null || $currentUrl !== null
+            ? redirect($nextUrl ?? $currentUrl)
+            : redirect()->back();
+    }
+
+    public function postBack(NewPlayerTourService $tour, SelectorService $selector): RedirectResponse
+    {
+        $tour->goBack(Auth::user());
+        return redirect($this->currentUrl($tour, $selector));
+    }
+
+    public function postSkip(NewPlayerTourService $tour): RedirectResponse
+    {
+        $tour->skip(Auth::user());
+        return redirect()->back();
+    }
+
+    public function postRestart(NewPlayerTourService $tour, SelectorService $selector): RedirectResponse
+    {
+        $tour->restart(Auth::user());
+        return redirect($this->currentUrl($tour, $selector));
+    }
+
+    private function currentUrl(NewPlayerTourService $tour, SelectorService $selector): string
+    {
+        return $tour->getCurrentStepUrl(Auth::user(), $this->selectedDominion($selector)) ?? route('dashboard');
+    }
+
+    private function selectedDominion(SelectorService $selector): ?Dominion
+    {
+        return $selector->hasUserSelectedDominion() ? $selector->getUserSelectedDominion() : null;
+    }
+}

--- a/src/Listeners/SetUserDefaultSettings.php
+++ b/src/Listeners/SetUserDefaultSettings.php
@@ -4,20 +4,26 @@ namespace OpenDominion\Listeners;
 
 use OpenDominion\Events\UserRegisteredEvent;
 use OpenDominion\Helpers\NotificationHelper;
+use OpenDominion\Services\NewPlayerTourService;
 
 class SetUserDefaultSettings
 {
     /** @var NotificationHelper */
     protected $notificationHelper;
 
+    /** @var NewPlayerTourService */
+    protected $newPlayerTourService;
+
     /**
      * SetUserDefaultSettings constructor.
      *
      * @param NotificationHelper $notificationHelper
+     * @param NewPlayerTourService $newPlayerTourService
      */
-    public function __construct(NotificationHelper $notificationHelper)
+    public function __construct(NotificationHelper $notificationHelper, NewPlayerTourService $newPlayerTourService)
     {
         $this->notificationHelper = $notificationHelper;
+        $this->newPlayerTourService = $newPlayerTourService;
     }
 
     /**
@@ -30,7 +36,9 @@ class SetUserDefaultSettings
     {
         $user = $event->getUser();
 
-        $settings = [];
+        $settings = [
+            NewPlayerTourService::SETTING_KEY => $this->newPlayerTourService->defaultState(),
+        ];
 
         // Notifications
         $settings['notifications'] = $this->notificationHelper->getDefaultUserNotificationSettings();

--- a/src/Providers/ComposerServiceProvider.php
+++ b/src/Providers/ComposerServiceProvider.php
@@ -18,6 +18,7 @@ use OpenDominion\Models\MessageBoard;
 use OpenDominion\Models\Valuable;
 use OpenDominion\Services\Dominion\ProtectionService;
 use OpenDominion\Services\Dominion\SelectorService;
+use OpenDominion\Services\NewPlayerTourService;
 
 class ComposerServiceProvider extends AbstractServiceProvider
 {
@@ -28,6 +29,31 @@ class ComposerServiceProvider extends AbstractServiceProvider
      */
     public function boot()
     {
+        view()->composer(['layouts.master', 'partials.main-sidebar', 'partials.mobile-bottom-nav'], function (View $view) {
+            // Included partials inherit this data from layouts.master. Avoid recomputing
+            // the tour when their composers run later in the same render.
+            if (array_key_exists('onboardingStage', $view->getData())) {
+                return;
+            }
+
+            $user = Auth::user();
+            if ($user === null) {
+                $view->with(['newPlayerTour' => null, 'onboardingStage' => null]);
+                return;
+            }
+
+            $selectorService = app(SelectorService::class);
+            $selectedDominion = $selectorService->hasUserSelectedDominion()
+                ? $selectorService->getUserSelectedDominion()
+                : null;
+
+            $view->with(app(NewPlayerTourService::class)->getViewData(
+                $user,
+                $selectedDominion,
+                request()
+            ));
+        });
+
         view()->composer('layouts.topnav', function (View $view) {
             $view->with('selectorService', app(SelectorService::class));
         });

--- a/src/Services/NewPlayerTourService.php
+++ b/src/Services/NewPlayerTourService.php
@@ -1,0 +1,488 @@
+<?php
+
+namespace OpenDominion\Services;
+
+use Illuminate\Http\Request;
+use OpenDominion\Models\Dominion;
+use OpenDominion\Models\User;
+use OpenDominion\Services\Dominion\HistoryService;
+use OpenDominion\Services\Dominion\ProtectionService;
+
+class NewPlayerTourService
+{
+    public const SETTING_KEY = 'new_player_tour';
+
+    public const STATUS_ACTIVE = 'active';
+    public const STATUS_COMPLETED = 'completed';
+    public const STATUS_SKIPPED = 'skipped';
+
+    private const PHASE_FOUNDATION = 'foundation';
+    private const PHASE_ACTIVE = 'active';
+    private const LAST_FOUNDATION_STEP = 'magic';
+
+    private const STEPS = [
+        'status' => [
+            'phase' => self::PHASE_FOUNDATION,
+            'navigation_stage' => 0,
+            'label' => 'Status',
+            'route' => 'dominion.status',
+            'matches' => ['dominion.status'],
+            'target' => 'status',
+            'title' => 'Your dominion at a glance',
+            'body' => 'Status is your command summary. The round goal is to finish with the most land: grow peacefully by exploring while maintaining your defenses, or gain land through conquest.',
+        ],
+        'quick_start' => [
+            'phase' => self::PHASE_FOUNDATION,
+            'navigation_stage' => 0,
+            'label' => 'Quick Start',
+            'route' => 'dominion.status',
+            'matches' => ['dominion.status', 'dominion.misc.restart'],
+            'target' => 'quick-start',
+            'nav' => 'status',
+            'title' => 'Choose your guided start',
+            'body' => 'Restart now to choose your race and select Quick Start. Your race defines your units, perks, spells, and strategic strengths. Quick Start begins with 500 acres and uses built-in checkpoints to guide the rest of protection.',
+            'completion' => 'quick_start',
+            'objective' => 'Open Restart & Rename, choose a race, select Quick Start, then press Restart.',
+        ],
+        'advisors' => [
+            'phase' => self::PHASE_FOUNDATION,
+            'navigation_stage' => 1,
+            'label' => 'Advisors',
+            'route' => 'dominion.advisors',
+            'matches' => ['dominion.advisors*'],
+            'target' => 'resources-overview',
+            'title' => 'Read the details',
+            'body' => 'Advisors break down production, military, magic, rankings, and statistics. The overview above tracks essentials such as land, platinum, food, lumber, mana, draftees, and defense.',
+        ],
+        'starting_buildings' => [
+            'phase' => self::PHASE_FOUNDATION,
+            'navigation_stage' => 4,
+            'label' => 'Starting Buildings',
+            'route' => 'dominion.protection.buildings',
+            'matches' => ['dominion.protection.buildings'],
+            'target' => 'starting-buildings',
+            'nav' => 'construction',
+            'title' => 'Build your opening',
+            'body' => 'Choose starting buildings for every acre. Homes support population; farms prevent starvation; resource buildings fund what comes next. You will also need barracks for military and mana plus wizards before you can use magic.',
+            'completion' => 'starting_buildings',
+            'objective' => 'Allocate every starting acre, then press Build.',
+        ],
+        'daily_bonus' => [
+            'phase' => self::PHASE_FOUNDATION,
+            'navigation_stage' => 4,
+            'label' => 'Daily Bonus',
+            'route' => 'dominion.bonuses',
+            'matches' => ['dominion.bonuses'],
+            'target' => 'daily-bonus',
+            'title' => 'Collect your daily bonuses',
+            'body' => 'Claim both bonuses each game day. Land directly grows your dominion; platinum and research help fund exploration, construction, military, and technology.',
+            'completion' => 'daily_bonuses',
+            'objective' => 'Claim both the Land Bonus and Platinum Bonus.',
+        ],
+        'discord' => [
+            'phase' => self::PHASE_FOUNDATION,
+            'navigation_stage' => 4,
+            'label' => 'Community',
+            'route' => 'dominion.bonuses',
+            'matches' => ['dominion.bonuses'],
+            'target' => 'discord-community',
+            'title' => 'Join the OpenDominion Discord',
+            'body' => 'Protection is a simulation, and questions are expected. Join Discord now so experienced players can help with your build, explain an unfamiliar choice, and later connect you with your realm mates.',
+        ],
+        'explore' => [
+            'phase' => self::PHASE_FOUNDATION,
+            'navigation_stage' => 4,
+            'label' => 'Explore Land',
+            'route' => 'dominion.explore',
+            'matches' => ['dominion.explore'],
+            'target' => 'explore',
+            'title' => 'Send your first exploration',
+            'body' => 'Exploring is how you grow without invading. It costs platinum and draftees per acre, and the land arrives over time. Growth is safest when your defense grows with it.',
+            'completion' => 'explore',
+            'objective' => 'Send at least one acre on exploration.',
+        ],
+        'construction' => [
+            'phase' => self::PHASE_FOUNDATION,
+            'navigation_stage' => 4,
+            'label' => 'Construction',
+            'route' => 'dominion.construct',
+            'matches' => ['dominion.construct'],
+            'target' => 'construction',
+            'title' => 'Queue your next buildings',
+            'body' => 'Explored land arrives barren. Construction turns it into the homes, farms, barracks, and resource buildings your plan needs. Ordinary construction costs platinum and lumber and completes after 12 hours.',
+            'completion' => 'construct',
+            'objective' => 'Submit at least one construction order.',
+        ],
+        'military' => [
+            'phase' => self::PHASE_FOUNDATION,
+            'navigation_stage' => 5,
+            'label' => 'Military',
+            'route' => 'dominion.military',
+            'matches' => ['dominion.military'],
+            'target' => 'military',
+            'title' => 'Train your first units',
+            'body' => 'Draftees become trained units here. Defensive power protects your land; offensive power and boats let you conquer it. If you cannot train yet, use protection hours to gain resources and construct the support you need, then return—never grow beyond what you can defend.',
+            'completion' => 'train',
+            'objective' => 'Advance and prepare as needed, then submit at least one military training order.',
+        ],
+        'magic' => [
+            'phase' => self::PHASE_FOUNDATION,
+            'navigation_stage' => 6,
+            'label' => 'Magic',
+            'route' => 'dominion.magic',
+            'matches' => ['dominion.magic'],
+            'target' => 'self-spells',
+            'title' => 'Maintain your self spells',
+            'body' => "At minimum, prepare to keep Midas Touch active whenever possible for its platinum bonus. Depending on your strategy, you will likely keep Ares' Call active always or frequently for defense. If you cannot cast yet, advance protection while building mana production and training wizards, then return.",
+            'completion' => 'self_spell',
+            'objective' => 'Successfully cast one self spell.',
+        ],
+        'realm' => [
+            'phase' => self::PHASE_ACTIVE,
+            'navigation_stage' => 7,
+            'label' => 'Realms',
+            'route' => 'dominion.realm',
+            'matches' => ['dominion.realm'],
+            'target' => 'realm',
+            'title' => 'Meet your team',
+            'body' => 'Your realm is your team. Coordinate plans, share information, and help cover one another as the round develops.',
+        ],
+        'rankings' => [
+            'phase' => self::PHASE_ACTIVE,
+            'navigation_stage' => 8,
+            'label' => 'Rankings',
+            'route' => 'dominion.rankings',
+            'matches' => ['dominion.rankings'],
+            'target' => 'rankings',
+            'title' => 'Keep the objective in sight',
+            'body' => 'Rankings show how dominions compare. The central objective is simple: end the round with the most land. Everything you have learned helps you choose how to get there.',
+        ],
+    ];
+
+    public function __construct(private ProtectionService $protectionService)
+    {
+    }
+
+    public function defaultState(bool $newAccount = true): array
+    {
+        return [
+            'status' => self::STATUS_ACTIVE,
+            'step' => array_key_first(self::STEPS),
+            'new_account' => $newAccount,
+        ];
+    }
+
+    public function getState(User $user): ?array
+    {
+        $state = $user->getSetting(self::SETTING_KEY);
+        if (!is_array($state) || !isset($state['status'])) {
+            return null;
+        }
+
+        return $state;
+    }
+
+    public function getActiveStep(User $user): ?string
+    {
+        $state = $this->getState($user);
+        if (($state['status'] ?? null) !== self::STATUS_ACTIVE || !isset(self::STEPS[$state['step'] ?? ''])) {
+            return null;
+        }
+
+        return $state['step'];
+    }
+
+    public function getStage(User $user, ?Dominion $dominion = null): ?int
+    {
+        $step = $this->getActiveStep($user);
+        if ($step === null) {
+            return null;
+        }
+
+        if ($dominion !== null && !$this->isStepAvailable($step, $dominion)) {
+            return null;
+        }
+
+        return self::STEPS[$step]['navigation_stage'];
+    }
+
+    public function getViewData(User $user, ?Dominion $dominion, Request $request): array
+    {
+        $stepKey = $this->getActiveStep($user);
+        if ($stepKey === null || $dominion === null) {
+            return ['newPlayerTour' => null, 'onboardingStage' => null];
+        }
+
+        $keys = array_keys(self::STEPS);
+        $index = (int)array_search($stepKey, $keys, true);
+        if (!$this->isStepAvailable($stepKey, $dominion)) {
+            return $this->getPausedViewData($stepKey, $dominion, $request);
+        }
+
+        $step = self::STEPS[$stepKey];
+        $protectionActionProgress = match ($stepKey) {
+            'explore' => $this->getProtectionActionProgress($dominion, HistoryService::EVENT_ACTION_EXPLORE),
+            'construction' => $this->getProtectionActionProgress($dominion, HistoryService::EVENT_ACTION_CONSTRUCT),
+            default => null,
+        };
+        $requiresQuickStart = $stepKey === 'quick_start' && $this->isNewAccountGuide($user);
+        if ($stepKey === 'quick_start' && !$requiresQuickStart) {
+            unset($step['completion'], $step['objective']);
+            $step['title'] = 'Quick Start for new dominions';
+            $step['body'] = 'Quick Start is the recommended guided opening for a new dominion. Because you restarted the field guide later, you can continue without resetting your current dominion.';
+        }
+        $startingBuildingsSelected = $stepKey === 'starting_buildings' && $this->hasStartingBuildingsSelection($dominion);
+        if ($startingBuildingsSelected && $dominion->isBuildingPhase()) {
+            $step['target'] = 'protection-confirm';
+            $step['title'] = 'Confirm your opening';
+            $step['body'] = 'Your starting layout is saved. OpenDominion lets you revise it until you confirm the choice and begin the first protection hour.';
+            $step['objective'] = 'Press Next » in the protection banner to confirm your buildings.';
+        }
+        if ($protectionActionProgress !== null && $protectionActionProgress['performed'] && !$protectionActionProgress['advanced']) {
+            $step['target'] = 'protection-confirm';
+            $step['title'] = $stepKey === 'explore' ? 'Bring your explored acres home' : 'Finish your construction';
+            $step['body'] = $stepKey === 'explore'
+                ? 'Your exploration order is queued. Advance Quick Start so the incoming acres arrive before you decide what to build on them.'
+                : 'Your building order is queued. Advance Quick Start so construction completes and your dominion is ready for military training.';
+            $step['objective'] = 'Press Next » in the protection banner to complete this stage.';
+        }
+        $step['key'] = $stepKey;
+        $step['nav'] = $step['nav'] ?? $stepKey;
+        $step['number'] = $index + 1;
+        $step['total'] = count($keys);
+        $step['phase_label'] = $step['phase'] === self::PHASE_ACTIVE ? 'ACTIVE PLAY' : 'FIELD GUIDE';
+        $step['paused'] = false;
+        $step['quest'] = isset($step['completion']);
+        $step['satisfied'] = !$step['quest'] ? true : ($stepKey === 'starting_buildings'
+            ? $startingBuildingsSelected && !$dominion->isBuildingPhase()
+            : ($protectionActionProgress['advanced'] ?? $this->isStepSatisfied($stepKey, $dominion)));
+        if ($requiresQuickStart && $step['satisfied']) {
+            $step['title'] = 'Quick Start is ready';
+            $step['body'] = 'Your race and Quick Start choice are recorded. Continue to allocate all 500 starting acres; the protection banner will then guide you through the remaining checkpoints.';
+        }
+        $step['objective'] = $step['objective'] ?? null;
+        $step['action_url'] = match ($stepKey) {
+            'quick_start' => $requiresQuickStart && !$step['satisfied'] ? route('dominion.misc.restart') : null,
+            'discord' => config('app.discord_invite_link') ?: 'https://discord.gg/mFk2wZT',
+            default => null,
+        };
+        $step['action_label'] = match ($stepKey) {
+            'quick_start' => 'Open Restart & Rename',
+            'discord' => 'Join Discord',
+            default => null,
+        };
+        $step['action_external'] = $stepKey === 'discord';
+        $step['progress_percent'] = (($index + 1) / count($keys)) * 100;
+        $step['progress_items'] = $this->getProgressItems($index, $dominion, $step['satisfied']);
+        $step['url'] = $this->getStepUrl($stepKey, $dominion);
+        $step['is_current_page'] = $request->routeIs(...$step['matches']);
+
+        return ['newPlayerTour' => $step, 'onboardingStage' => $this->getStage($user, $dominion)];
+    }
+
+    public function advance(User $user, ?Dominion $dominion): bool
+    {
+        $step = $this->getActiveStep($user);
+        if ($step === null || $dominion === null) {
+            return false;
+        }
+
+        $requiresCompletion = $step !== 'quick_start' || $this->isNewAccountGuide($user);
+        if (!$this->isStepAvailable($step, $dominion) || ($requiresCompletion && !$this->isStepSatisfied($step, $dominion))) {
+            return false;
+        }
+
+        $keys = array_keys(self::STEPS);
+        $index = array_search($step, $keys, true);
+        if ($index === count($keys) - 1) {
+            $this->setState($user, ['status' => self::STATUS_COMPLETED, 'step' => $step]);
+            return true;
+        }
+
+        $this->setState($user, ['status' => self::STATUS_ACTIVE, 'step' => $keys[$index + 1]]);
+        return true;
+    }
+
+    public function goBack(User $user): void
+    {
+        $step = $this->getActiveStep($user);
+        if ($step === null) {
+            return;
+        }
+
+        $keys = array_keys(self::STEPS);
+        $index = array_search($step, $keys, true);
+        $this->setState($user, ['status' => self::STATUS_ACTIVE, 'step' => $keys[max(0, $index - 1)]]);
+    }
+
+    public function skip(User $user): void
+    {
+        $step = $this->getActiveStep($user) ?? array_key_first(self::STEPS);
+        $this->setState($user, ['status' => self::STATUS_SKIPPED, 'step' => $step]);
+    }
+
+    public function restart(User $user): void
+    {
+        $this->setState($user, $this->defaultState(false));
+    }
+
+    public function getCurrentStepUrl(User $user, ?Dominion $dominion): ?string
+    {
+        $step = $this->getActiveStep($user);
+        return $step === null || $dominion === null || !$this->isStepAvailable($step, $dominion)
+            ? null
+            : $this->getStepUrl($step, $dominion);
+    }
+
+    private function getPausedViewData(string $stepKey, Dominion $dominion, Request $request): array
+    {
+        $keys = array_keys(self::STEPS);
+        $index = (int)array_search($stepKey, $keys, true);
+        $foundationIndex = (int)array_search(self::LAST_FOUNDATION_STEP, $keys, true);
+        $lastFoundation = self::STEPS[self::LAST_FOUNDATION_STEP];
+
+        $step = [
+            'key' => $stepKey,
+            'nav' => self::LAST_FOUNDATION_STEP,
+            'target' => $lastFoundation['target'],
+            'matches' => $lastFoundation['matches'],
+            'label' => 'Active play',
+            'title' => 'Protection chapter complete',
+            'body' => 'Keep training troops and complete your remaining protection hours. Feel free to explore the now-unlocked pages and get familiar with the game, and ask questions in Discord whenever you need help. The guide will resume with Realms and Rankings after protection ends and realm assignment is complete.',
+            'number' => $foundationIndex + 1,
+            'total' => count($keys),
+            'phase_label' => 'CHAPTER COMPLETE',
+            'paused' => true,
+            'quest' => false,
+            'satisfied' => true,
+            'objective' => null,
+            'action_url' => route('dominion.misc.restart'),
+            'action_label' => 'Restart or Rename',
+            'action_external' => false,
+            'progress_percent' => (($foundationIndex + 1) / count($keys)) * 100,
+            'progress_items' => $this->getProgressItems($index, $dominion),
+            'url' => null,
+            'is_current_page' => $request->routeIs(...$lastFoundation['matches']),
+        ];
+
+        return ['newPlayerTour' => $step, 'onboardingStage' => null];
+    }
+
+    private function getProgressItems(int $currentIndex, Dominion $dominion, bool $currentSatisfied = false): array
+    {
+        $items = [];
+        foreach (array_keys(self::STEPS) as $index => $key) {
+            $step = self::STEPS[$key];
+            if ($index < $currentIndex) {
+                $state = 'completed';
+            } elseif (!$this->isStepAvailable($key, $dominion)) {
+                $state = 'locked';
+            } elseif ($index === $currentIndex) {
+                $state = isset($step['completion']) && $currentSatisfied ? 'ready' : 'current';
+            } else {
+                $state = 'upcoming';
+            }
+
+            $items[] = ['label' => $step['label'], 'state' => $state];
+        }
+
+        return $items;
+    }
+
+    private function isStepAvailable(string $step, Dominion $dominion): bool
+    {
+        if (self::STEPS[$step]['phase'] === self::PHASE_FOUNDATION) {
+            return true;
+        }
+
+        return !$this->protectionService->isUnderProtection($dominion)
+            && $dominion->round->hasAssignedRealms();
+    }
+
+    private function isStepSatisfied(string $step, Dominion $dominion): bool
+    {
+        $completion = self::STEPS[$step]['completion'] ?? null;
+        if ($completion === null) {
+            return true;
+        }
+
+        return match ($completion) {
+            'quick_start' => data_get(
+                $dominion->history()
+                    ->where('event', HistoryService::EVENT_ACTION_RESTART)
+                    ->latest('id')
+                    ->first(['delta']),
+                'delta.action'
+            ) === 'quick',
+            'starting_buildings' => !$dominion->isBuildingPhase() && $this->hasStartingBuildingsSelection($dominion),
+            'daily_bonuses' => $dominion->history()
+                ->where('event', HistoryService::EVENT_ACTION_DAILY_BONUS)
+                ->where('delta->daily_land', true)
+                ->exists()
+                && $dominion->history()
+                    ->where('event', HistoryService::EVENT_ACTION_DAILY_BONUS)
+                    ->where('delta->daily_platinum', true)
+                    ->exists(),
+            'explore' => $this->getProtectionActionProgress($dominion, HistoryService::EVENT_ACTION_EXPLORE)['advanced'],
+            'construct' => $this->getProtectionActionProgress($dominion, HistoryService::EVENT_ACTION_CONSTRUCT)['advanced'],
+            'train' => $dominion->history()
+                ->where('event', HistoryService::EVENT_ACTION_TRAIN)
+                ->exists(),
+            'self_spell' => $dominion->history()
+                ->where('event', HistoryService::EVENT_ACTION_CAST_SPELL)
+                ->whereRaw("JSON_LENGTH(JSON_EXTRACT(delta, '$.queue.active_spells')) > 0")
+                ->exists(),
+            default => false,
+        };
+    }
+
+    private function hasStartingBuildingsSelection(Dominion $dominion): bool
+    {
+        return $dominion->history()
+            ->where('event', HistoryService::EVENT_TICK)
+            ->where('delta->action', 'starting_buildings')
+            ->exists();
+    }
+
+    private function getProtectionActionProgress(Dominion $dominion, string $event): array
+    {
+        $actionId = $dominion->history()
+            ->where('event', $event)
+            ->latest('id')
+            ->value('id');
+
+        return [
+            'performed' => $actionId !== null,
+            'advanced' => $actionId !== null
+                && (
+                    !$this->protectionService->isUnderProtection($dominion)
+                    || $dominion->history()
+                        ->where('event', HistoryService::EVENT_ACTION_PROTECTION_ADVANCE_TICK)
+                        ->where('id', '>', $actionId)
+                        ->exists()
+                ),
+        ];
+    }
+
+    private function getStepUrl(string $step, Dominion $dominion): string
+    {
+        if ($step === 'starting_buildings' && $dominion->isBuildingPhase()) {
+            return route('dominion.protection.buildings');
+        }
+
+        return route(self::STEPS[$step]['route']);
+    }
+
+    private function isNewAccountGuide(User $user): bool
+    {
+        return (bool)($this->getState($user)['new_account'] ?? true);
+    }
+
+    private function setState(User $user, array $state): void
+    {
+        $settings = $user->settings ?? [];
+        $settings[self::SETTING_KEY] = array_merge($this->getState($user) ?? [], $state);
+        $user->settings = $settings;
+        $user->save();
+    }
+}

--- a/tests/Http/Auth/RegisterTest.php
+++ b/tests/Http/Auth/RegisterTest.php
@@ -6,6 +6,7 @@ use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Notification;
 use OpenDominion\Models\User;
 use OpenDominion\Notifications\User\RegisteredNotification;
+use OpenDominion\Services\NewPlayerTourService;
 use OpenDominion\Tests\AbstractBrowserKitTestCase;
 
 class RegisterTest extends AbstractBrowserKitTestCase
@@ -39,6 +40,10 @@ class RegisterTest extends AbstractBrowserKitTestCase
 
         $user = User::where('email', 'johndoe@example.com')->firstOrFail();
 
+        $this->assertSame(
+            ['status' => NewPlayerTourService::STATUS_ACTIVE, 'step' => 'status', 'new_account' => true],
+            $user->getSetting(NewPlayerTourService::SETTING_KEY)
+        );
         Notification::assertSentTo($user, RegisteredNotification::class);
     }
 

--- a/tests/Http/NewPlayerTourTest.php
+++ b/tests/Http/NewPlayerTourTest.php
@@ -1,0 +1,456 @@
+<?php
+
+namespace OpenDominion\Tests\Http;
+
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use OpenDominion\Services\Dominion\HistoryService;
+use OpenDominion\Services\NewPlayerTourService;
+use OpenDominion\Tests\AbstractBrowserKitTestCase;
+
+class NewPlayerTourTest extends AbstractBrowserKitTestCase
+{
+    use DatabaseTransactions;
+
+    public function testExistingUserWithoutTourStateKeepsCompleteNavigation(): void
+    {
+        $user = $this->createAndImpersonateUser();
+        $round = $this->createRound();
+        $this->createAndSelectDominion($user, $round);
+
+        $this->visitRoute('dominion.status')
+            ->dontSeeElement('[data-new-player-tour]')
+            ->seeElement('[data-onboarding-nav="status"]')
+            ->seeElement('[data-onboarding-nav="advisors"]')
+            ->seeElement('[data-onboarding-nav="explore"]')
+            ->seeElement('[data-onboarding-nav="military"]')
+            ->seeElement('[data-onboarding-nav="magic"]')
+            ->seeElement('[data-onboarding-nav="realm"]')
+            ->seeElement('[data-onboarding-nav="rankings"]');
+    }
+
+    public function testActiveTourStartsWithOnlyStatusRevealed(): void
+    {
+        $user = $this->createAndImpersonateUser(null, [
+            'settings' => [NewPlayerTourService::SETTING_KEY => app(NewPlayerTourService::class)->defaultState()],
+        ]);
+        $round = $this->createRound();
+        $this->createAndSelectDominion($user, $round);
+
+        $this->visitRoute('dominion.status')
+            ->seeElement('[data-new-player-tour]')
+            ->seeElement('[data-onboarding-nav="status"]')
+            ->dontSeeElement('[data-onboarding-nav="advisors"]')
+            ->dontSeeElement('[data-onboarding-nav="explore"]')
+            ->dontSeeElement('[data-onboarding-nav="military"]');
+    }
+
+    public function testCompletingStatusMovesToQuickStartBeforeAdvisors(): void
+    {
+        $user = $this->createAndImpersonateUser(null, [
+            'settings' => [NewPlayerTourService::SETTING_KEY => app(NewPlayerTourService::class)->defaultState()],
+        ]);
+        $round = $this->createRound();
+        $this->createAndSelectDominion($user, $round);
+
+        $this->visitRoute('dominion.status')
+            ->press('Continue')
+            ->seeRouteIs('dominion.status')
+            ->see('Choose your guided start')
+            ->dontSeeElement('[data-onboarding-nav="advisors"]')
+            ->dontSeeElement('[data-onboarding-nav="daily_bonus"]');
+
+        $this->assertSame('quick_start', $user->fresh()->getSetting(NewPlayerTourService::SETTING_KEY)['step']);
+    }
+
+    public function testStartingBuildingsStageRevealsRezoneButNotOtherDominionPages(): void
+    {
+        $user = $this->createAndImpersonateUser(null, [
+            'settings' => [NewPlayerTourService::SETTING_KEY => ['status' => 'active', 'step' => 'starting_buildings']],
+        ]);
+        $round = $this->createRound();
+        $this->createAndSelectDominion($user, $round);
+
+        $this->visitRoute('dominion.protection.buildings')
+            ->seeElement('[data-onboarding-nav="construction"]')
+            ->seeElement('a[href="' . route('dominion.rezone') . '"]')
+            ->dontSeeElement('a[href="' . route('dominion.improvements') . '"]')
+            ->dontSeeElement('[data-onboarding-nav="military"]');
+    }
+
+    public function testVerifiedQuestSequenceRequiresRecordedGameActions(): void
+    {
+        $user = $this->createAndImpersonateUser(null, [
+            'settings' => [NewPlayerTourService::SETTING_KEY => ['status' => 'active', 'step' => 'starting_buildings']],
+        ]);
+        $round = $this->createRound();
+        $dominion = $this->createAndSelectDominion($user, $round);
+        $tour = app(NewPlayerTourService::class);
+
+        $this->assertFalse($tour->advance($user, $dominion));
+        $dominion->history()->create(['event' => HistoryService::EVENT_TICK, 'delta' => ['action' => 'starting_buildings']]);
+        $this->assertFalse($tour->advance($user, $dominion));
+        $dominion->update(['protection_ticks_remaining' => $dominion->protection_ticks]);
+        $this->assertTrue($tour->advance($user, $dominion));
+        $this->assertSame('daily_bonus', $user->getSetting(NewPlayerTourService::SETTING_KEY)['step']);
+
+        $this->assertFalse($tour->advance($user, $dominion));
+        $dominion->history()->create(['event' => HistoryService::EVENT_ACTION_DAILY_BONUS, 'delta' => ['daily_land' => true]]);
+        $dominion->history()->create(['event' => HistoryService::EVENT_ACTION_DAILY_BONUS, 'delta' => ['daily_platinum' => true]]);
+        $this->assertTrue($tour->advance($user, $dominion));
+        $this->assertSame('discord', $user->getSetting(NewPlayerTourService::SETTING_KEY)['step']);
+
+        $this->assertTrue($tour->advance($user, $dominion));
+        $this->assertSame('explore', $user->getSetting(NewPlayerTourService::SETTING_KEY)['step']);
+
+        $this->assertFalse($tour->advance($user, $dominion));
+        $dominion->history()->create(['event' => HistoryService::EVENT_ACTION_EXPLORE, 'delta' => ['queue' => ['exploration' => ['land_plain' => 1]]]]);
+        $this->assertFalse($tour->advance($user, $dominion));
+        $dominion->history()->create(['event' => HistoryService::EVENT_ACTION_PROTECTION_ADVANCE_TICK, 'delta' => []]);
+        $this->assertTrue($tour->advance($user, $dominion));
+        $this->assertSame('construction', $user->getSetting(NewPlayerTourService::SETTING_KEY)['step']);
+
+        $this->assertFalse($tour->advance($user, $dominion));
+        $dominion->history()->create(['event' => HistoryService::EVENT_ACTION_CONSTRUCT, 'delta' => ['queue' => ['construction' => ['building_home' => 1]]]]);
+        $this->assertFalse($tour->advance($user, $dominion));
+        $dominion->history()->create(['event' => HistoryService::EVENT_ACTION_PROTECTION_ADVANCE_TICK, 'delta' => []]);
+        $this->assertTrue($tour->advance($user, $dominion));
+        $this->assertSame('military', $user->getSetting(NewPlayerTourService::SETTING_KEY)['step']);
+
+        $this->assertFalse($tour->advance($user, $dominion));
+        $dominion->history()->create(['event' => HistoryService::EVENT_ACTION_TRAIN, 'delta' => ['queue' => ['training' => ['military_unit1' => 1]]]]);
+        $this->assertTrue($tour->advance($user, $dominion));
+        $this->assertSame('magic', $user->getSetting(NewPlayerTourService::SETTING_KEY)['step']);
+
+        $this->assertFalse($tour->advance($user, $dominion));
+        $dominion->history()->create(['event' => HistoryService::EVENT_ACTION_CAST_SPELL, 'delta' => ['queue' => ['active_spells' => ['midas_touch' => 12]]]]);
+        $this->assertTrue($tour->advance($user, $dominion));
+        $this->assertSame('realm', $user->getSetting(NewPlayerTourService::SETTING_KEY)['step']);
+    }
+
+    public function testNewAccountQuickStartStepRequiresQuickProtection(): void
+    {
+        $user = $this->createAndImpersonateUser(null, [
+            'settings' => [NewPlayerTourService::SETTING_KEY => ['status' => 'active', 'step' => 'quick_start', 'new_account' => true]],
+        ]);
+        $round = $this->createRound();
+        $dominion = $this->createAndSelectDominion($user, $round);
+        $tour = app(NewPlayerTourService::class);
+
+        $this->visitRoute('dominion.status')
+            ->see('Choose your guided start')
+            ->see('Open Restart & Rename')
+            ->see('choose your race and select Quick Start');
+
+        $this->assertFalse($tour->advance($user, $dominion));
+
+        $this->visitRoute('dominion.misc.restart')
+            ->seeElement('[data-onboarding-target="quick-start"]')
+            ->see('Your race defines your units, perks, spells, and strategic strengths.');
+
+        $dominion->history()->create([
+            'event' => HistoryService::EVENT_ACTION_RESTART,
+            'delta' => ['action' => 'quick'],
+        ]);
+        $this->assertTrue($tour->advance($user, $dominion));
+        $this->assertSame('advisors', $user->getSetting(NewPlayerTourService::SETTING_KEY)['step']);
+
+        $this->assertTrue($tour->advance($user, $dominion));
+        $this->assertSame('starting_buildings', $user->getSetting(NewPlayerTourService::SETTING_KEY)['step']);
+    }
+
+    public function testRestartedGuideDoesNotRequireDominionRestart(): void
+    {
+        $user = $this->createAndImpersonateUser(null, [
+            'settings' => [NewPlayerTourService::SETTING_KEY => ['status' => 'active', 'step' => 'quick_start', 'new_account' => false]],
+        ]);
+        $round = $this->createRound();
+        $dominion = $this->createAndSelectDominion($user, $round);
+
+        $this->visitRoute('dominion.status')
+            ->see('Quick Start for new dominions')
+            ->see('continue without resetting your current dominion')
+            ->dontSee('Open Restart & Rename')
+            ->press('Continue');
+
+        $this->assertSame('advisors', $user->fresh()->getSetting(NewPlayerTourService::SETTING_KEY)['step']);
+        $this->assertNotSame('quick', $dominion->fresh()->protection_type);
+    }
+
+    public function testCommunityLessonIncludesDirectDiscordInvite(): void
+    {
+        $user = $this->createAndImpersonateUser(null, [
+            'settings' => [NewPlayerTourService::SETTING_KEY => ['status' => 'active', 'step' => 'discord']],
+        ]);
+        $round = $this->createRound();
+        $this->createAndSelectDominion($user, $round);
+
+        $this->visitRoute('dominion.bonuses')
+            ->see('Join the OpenDominion Discord')
+            ->seeLink('Join Discord', 'https://discord.gg/mFk2wZT')
+            ->seeElement('a[href="https://discord.gg/mFk2wZT"][target="_blank"]');
+    }
+
+    public function testOutstandingQuestShowsObjectiveWithoutContinue(): void
+    {
+        $user = $this->createAndImpersonateUser(null, [
+            'settings' => [NewPlayerTourService::SETTING_KEY => ['status' => 'active', 'step' => 'explore']],
+        ]);
+        $round = $this->createRound();
+        $this->createAndSelectDominion($user, $round);
+
+        $this->visitRoute('dominion.explore')
+            ->see('Your objective')
+            ->see('Send at least one acre on exploration.')
+            ->dontSeeElement('form[action="' . route('new-player-tour.advance') . '"]');
+    }
+
+    public function testConstructionAfterExploreIsSeparateVerifiedQuest(): void
+    {
+        $user = $this->createAndImpersonateUser(null, [
+            'settings' => [NewPlayerTourService::SETTING_KEY => ['status' => 'active', 'step' => 'construction']],
+        ]);
+        $round = $this->createRound();
+        $this->createAndSelectDominion($user, $round);
+
+        $this->visitRoute('dominion.construct')
+            ->see('Queue your next buildings')
+            ->see('Submit at least one construction order.')
+            ->seeElement('[data-onboarding-target="construction"]')
+            ->dontSeeElement('form[action="' . route('new-player-tour.advance') . '"]');
+    }
+
+    public function testSavedStartingBuildingsRequireProtectionConfirmation(): void
+    {
+        $user = $this->createAndImpersonateUser(null, [
+            'settings' => [NewPlayerTourService::SETTING_KEY => ['status' => 'active', 'step' => 'starting_buildings']],
+        ]);
+        $round = $this->createRound();
+        $dominion = $this->createAndSelectDominion($user, $round);
+        $dominion->history()->create([
+            'event' => HistoryService::EVENT_TICK,
+            'delta' => ['action' => 'starting_buildings'],
+        ]);
+
+        $this->visitRoute('dominion.protection.buildings')
+            ->see('Confirm your opening')
+            ->see('Press Next » in the protection banner')
+            ->seeElement('[data-onboarding-target="protection-confirm"]')
+            ->dontSeeElement('form[action="' . route('new-player-tour.advance') . '"]');
+    }
+
+    public function testSatisfiedQuestShowsCompletionAndContinueAction(): void
+    {
+        $user = $this->createAndImpersonateUser(null, [
+            'settings' => [NewPlayerTourService::SETTING_KEY => ['status' => 'active', 'step' => 'explore']],
+        ]);
+        $round = $this->createRound();
+        $dominion = $this->createAndSelectDominion($user, $round);
+        $dominion->history()->create([
+            'event' => HistoryService::EVENT_ACTION_EXPLORE,
+            'delta' => ['queue' => ['exploration' => ['land_plain' => 1]]],
+        ]);
+        $dominion->history()->create([
+            'event' => HistoryService::EVENT_ACTION_PROTECTION_ADVANCE_TICK,
+            'delta' => [],
+        ]);
+
+        $this->visitRoute('dominion.explore')
+            ->see('Quest complete')
+            ->see('Continue quest')
+            ->seeElement('form[action="' . route('new-player-tour.advance') . '"]');
+    }
+
+    public function testQueuedExploreRequiresProtectionAdvanceBeforeContinue(): void
+    {
+        $user = $this->createAndImpersonateUser(null, [
+            'settings' => [NewPlayerTourService::SETTING_KEY => ['status' => 'active', 'step' => 'explore']],
+        ]);
+        $round = $this->createRound();
+        $dominion = $this->createAndSelectDominion($user, $round);
+        $dominion->history()->create([
+            'event' => HistoryService::EVENT_ACTION_EXPLORE,
+            'delta' => ['queue' => ['exploration' => ['land_plain' => 1]]],
+        ]);
+
+        $this->visitRoute('dominion.explore')
+            ->see('Bring your explored acres home')
+            ->see('Press Next » in the protection banner')
+            ->seeElement('[data-onboarding-target="protection-confirm"]')
+            ->dontSeeElement('form[action="' . route('new-player-tour.advance') . '"]');
+    }
+
+    public function testQueuedConstructionRequiresProtectionAdvanceBeforeContinue(): void
+    {
+        $user = $this->createAndImpersonateUser(null, [
+            'settings' => [NewPlayerTourService::SETTING_KEY => ['status' => 'active', 'step' => 'construction']],
+        ]);
+        $round = $this->createRound();
+        $dominion = $this->createAndSelectDominion($user, $round);
+        $dominion->history()->create([
+            'event' => HistoryService::EVENT_ACTION_CONSTRUCT,
+            'delta' => ['queue' => ['construction' => ['building_home' => 1]]],
+        ]);
+
+        $this->visitRoute('dominion.construct')
+            ->see('Finish your construction')
+            ->see('ready for military training')
+            ->seeElement('[data-onboarding-target="protection-confirm"]')
+            ->dontSeeElement('form[action="' . route('new-player-tour.advance') . '"]');
+    }
+
+    public function testExploreAndConstructionNeedOnlyTheirActionsAfterProtection(): void
+    {
+        $user = $this->createAndImpersonateUser(null, [
+            'settings' => [NewPlayerTourService::SETTING_KEY => ['status' => 'active', 'step' => 'explore', 'new_account' => false]],
+        ]);
+        $round = $this->createRound('-5 days');
+        $dominion = $this->createAndSelectDominion($user, $round);
+        $dominion->update(['protection_finished' => true]);
+        $tour = app(NewPlayerTourService::class);
+
+        $dominion->history()->create([
+            'event' => HistoryService::EVENT_ACTION_EXPLORE,
+            'delta' => ['queue' => ['exploration' => ['land_plain' => 1]]],
+        ]);
+        $this->assertTrue($tour->advance($user, $dominion));
+        $this->assertSame('construction', $user->fresh()->getSetting(NewPlayerTourService::SETTING_KEY)['step']);
+
+        $dominion->history()->create([
+            'event' => HistoryService::EVENT_ACTION_CONSTRUCT,
+            'delta' => ['queue' => ['construction' => ['building_home' => 1]]],
+        ]);
+        $this->assertTrue($tour->advance($user, $dominion));
+        $this->assertSame('military', $user->fresh()->getSetting(NewPlayerTourService::SETTING_KEY)['step']);
+    }
+
+    public function testDailyBonusRequiresOneClaimOfEachType(): void
+    {
+        $user = $this->createAndImpersonateUser(null, [
+            'settings' => [NewPlayerTourService::SETTING_KEY => ['status' => 'active', 'step' => 'daily_bonus']],
+        ]);
+        $round = $this->createRound();
+        $dominion = $this->createAndSelectDominion($user, $round);
+        $tour = app(NewPlayerTourService::class);
+
+        $dominion->history()->create(['event' => HistoryService::EVENT_ACTION_DAILY_BONUS, 'delta' => ['daily_land' => true]]);
+        $dominion->history()->create(['event' => HistoryService::EVENT_ACTION_DAILY_BONUS, 'delta' => ['daily_land' => true]]);
+        $this->assertFalse($tour->advance($user, $dominion));
+
+        $dominion->history()->create(['event' => HistoryService::EVENT_ACTION_DAILY_BONUS, 'delta' => ['daily_platinum' => true]]);
+        $this->assertTrue($tour->advance($user, $dominion));
+        $this->assertSame('discord', $user->fresh()->getSetting(NewPlayerTourService::SETTING_KEY)['step']);
+    }
+
+    public function testMagicLessonLeadsToProtectionCheckpointBeforeRealmLesson(): void
+    {
+        $user = $this->createAndImpersonateUser(null, [
+            'settings' => [NewPlayerTourService::SETTING_KEY => ['status' => 'active', 'step' => 'magic']],
+        ]);
+        $round = $this->createRound();
+        $dominion = $this->createAndSelectDominion($user, $round);
+        $dominion->history()->create([
+            'event' => HistoryService::EVENT_ACTION_CAST_SPELL,
+            'delta' => ['queue' => ['active_spells' => ['midas_touch' => 12]]],
+        ]);
+
+        $this->visitRoute('dominion.magic')
+            ->press('Continue quest')
+            ->seeRouteIs('dominion.magic')
+            ->see('Protection chapter complete')
+            ->see('Keep training troops and complete your remaining protection hours')
+            ->see('ask questions in Discord')
+            ->see('The guide will resume with Realms and Rankings')
+            ->see('Restart or Rename')
+            ->dontSeeElement('form[action="' . route('new-player-tour.advance') . '"]')
+            ->seeElement('[data-onboarding-nav="realm"]')
+            ->seeElement('[data-onboarding-nav="rankings"]');
+
+        $this->assertSame('realm', $user->fresh()->getSetting(NewPlayerTourService::SETTING_KEY)['step']);
+    }
+
+    public function testPausedActiveLessonCannotAdvanceWhileUnderProtection(): void
+    {
+        $user = $this->createAndImpersonateUser(null, [
+            'settings' => [NewPlayerTourService::SETTING_KEY => ['status' => 'active', 'step' => 'realm']],
+        ]);
+        $round = $this->createRound();
+        $dominion = $this->createAndSelectDominion($user, $round);
+
+        app(NewPlayerTourService::class)->advance($user, $dominion);
+
+        $this->assertSame('realm', $user->fresh()->getSetting(NewPlayerTourService::SETTING_KEY)['step']);
+    }
+
+    public function testRealmLessonResumesAfterProtectionAndRealmAssignment(): void
+    {
+        $user = $this->createAndImpersonateUser(null, [
+            'settings' => [NewPlayerTourService::SETTING_KEY => ['status' => 'active', 'step' => 'realm']],
+        ]);
+        $round = $this->createRound('-5 days');
+        $round->update(['assignment_complete' => true]);
+        $dominion = $this->createAndSelectDominion($user, $round);
+        $dominion->update(['protection_finished' => true]);
+
+        $this->visitRoute('dominion.realm')
+            ->see('Meet your team')
+            ->seeElement('[data-new-player-tour]')
+            ->seeElement('[data-onboarding-nav="realm"]')
+            ->dontSeeElement('[data-onboarding-nav="rankings"]');
+    }
+
+    public function testSkipRevealsEverythingAndPreservesSkippedState(): void
+    {
+        $user = $this->createAndImpersonateUser(null, [
+            'settings' => [NewPlayerTourService::SETTING_KEY => app(NewPlayerTourService::class)->defaultState()],
+        ]);
+        $round = $this->createRound();
+        $this->createAndSelectDominion($user, $round);
+
+        $this->visitRoute('dominion.status')
+            ->press('Skip guide')
+            ->seeElement('[data-onboarding-nav="advisors"]')
+            ->seeElement('[data-onboarding-nav="rankings"]')
+            ->dontSeeElement('[data-new-player-tour]');
+
+        $this->assertSame('skipped', $user->fresh()->getSetting(NewPlayerTourService::SETTING_KEY)['status']);
+    }
+
+    public function testAnyUserCanRestartGuideFromSettings(): void
+    {
+        $user = $this->createAndImpersonateUser(null, [
+            'settings' => [NewPlayerTourService::SETTING_KEY => ['status' => 'completed', 'step' => 'rankings']],
+        ]);
+        $round = $this->createRound();
+        $this->createAndSelectDominion($user, $round);
+
+        $this->visitRoute('settings')
+            ->press('Restart Game Guide')
+            ->seeRouteIs('dominion.status')
+            ->seeElement('[data-new-player-tour]');
+
+        $this->assertSame(
+            ['status' => 'active', 'step' => 'status', 'new_account' => false],
+            $user->fresh()->getSetting(NewPlayerTourService::SETTING_KEY)
+        );
+    }
+
+    public function testFinishingGuideStaysOnRankingsAndRevealsFullNavigation(): void
+    {
+        $user = $this->createAndImpersonateUser(null, [
+            'settings' => [NewPlayerTourService::SETTING_KEY => ['status' => 'active', 'step' => 'rankings']],
+        ]);
+        $round = $this->createRound('-5 days');
+        $round->update(['assignment_complete' => true]);
+        $dominion = $this->createAndSelectDominion($user, $round);
+        $dominion->update(['protection_finished' => true]);
+
+        $this->visitRoute('dominion.rankings')
+            ->press('Finish guide')
+            ->seeRouteIs('dominion.rankings', ['largest-dominions'])
+            ->dontSeeElement('[data-new-player-tour]')
+            ->seeElement('[data-onboarding-nav="status"]')
+            ->seeElement('[data-onboarding-nav="rankings"]');
+
+        $this->assertSame('completed', $user->fresh()->getSetting(NewPlayerTourService::SETTING_KEY)['status']);
+    }
+}


### PR DESCRIPTION
## Description

Adds an optional, progressive new-player field guide that introduces OpenDominion's core pages and turns protection setup into verified, quest-like steps.

The guide:

- starts automatically for newly registered accounts and can be skipped or restarted from settings;
- progressively reveals desktop and mobile navigation as concepts are introduced;
- walks through Status, Quick Start, Advisors, Starting Buildings, Daily Bonuses, Community, Explore, Construction, Military, Magic, Realms, and Rankings;
- verifies gameplay actions from dominion history instead of trusting browser-only state;
- requires Quick Start protection advances after exploration and construction while under protection;
- pauses after the protection chapter, reveals the full navigation, and resumes Realm/Rankings lessons when those pages become available;
- provides a responsive, collapsible guide with desktop dragging and accessible focus behavior.

## Motivation and Context

OpenDominion exposes many systems and navigation destinations immediately, which can overwhelm a new player before they understand the protection simulation or the round objective. This provides a focused path through the most important mechanics while preserving an immediate skip option and allowing established players to replay the informational guide without resetting their dominion.

## How Has This Been Tested?

- Added focused HTTP coverage for registration defaults, navigation stages, skip/restart behavior, new-account versus replay behavior, verified quest predicates, protection confirmation gates, post-protection replay, chapter pausing, and final completion.
- `31` focused tests pass with `218` assertions.
- The full suite executed `452` tests; one pre-existing random Faker duplicate-email collision occurred, and that exact test passed immediately in isolation.
- Production Vite build completed successfully.
- Blade templates compiled successfully.
- Desktop and mobile flows were reviewed interactively in the local Docker environment.
- `git diff --check` passes.

## Screenshots (if appropriate):

The guide was reviewed locally across desktop and mobile layouts; screenshots can be added if useful during review.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
