### PR TITLE
Improve dominion settings button

### DIFF
--- a/app/resources/views/partials/resources-overview.blade.php
+++ b/app/resources/views/partials/resources-overview.blade.php
@@ -28,10 +28,11 @@
         }
     @endphp
     <div class="card">
-        <div class="card-header">
-            <span class="card-title"><i class="fa fa-bar-chart"></i> Overview - {{ $selectedDominion->name }}</span>
-            <a href="{{ route('dominion.misc.settings') }}" title="Resource Display Settings" data-bs-toggle="tooltip">
-                <i class="fa fa-cog fa-sm"></i>
+        <div class="card-header d-flex align-items-center justify-content-between gap-3">
+            <span class="card-title flex-grow-1"><i class="fa fa-bar-chart"></i> Overview - {{ $selectedDominion->name }}</span>
+            <a class="btn btn-sm btn-outline-secondary flex-shrink-0 dominion-settings-button" href="{{ route('dominion.misc.settings') }}" aria-label="Dominion settings" title="Dominion Settings" data-bs-toggle="tooltip" data-bs-placement="left">
+                <i class="fa fa-sliders me-sm-1" aria-hidden="true"></i>
+                <span class="d-none d-sm-inline">Settings</span>
             </a>
         </div>
         <div class="card-body small">

--- a/tests/Unit/ResourcesOverviewMarkupTest.php
+++ b/tests/Unit/ResourcesOverviewMarkupTest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace OpenDominion\Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+
+class ResourcesOverviewMarkupTest extends TestCase
+{
+    public function testDominionSettingsButtonIsSeparatedFromTheDominionName(): void
+    {
+        $markup = file_get_contents(__DIR__.'/../../app/resources/views/partials/resources-overview.blade.php');
+
+        $titlePosition = strpos($markup, '<span class="card-title flex-grow-1">');
+        $settingsButtonPosition = strpos($markup, '<a class="btn btn-sm btn-outline-secondary flex-shrink-0 dominion-settings-button"');
+
+        $this->assertNotFalse($titlePosition);
+        $this->assertNotFalse($settingsButtonPosition);
+        $this->assertGreaterThan($titlePosition, $settingsButtonPosition);
+        $this->assertStringContainsString('card-header d-flex align-items-center justify-content-between gap-3', $markup);
+        $this->assertStringContainsString('aria-label="Dominion settings"', $markup);
+        $this->assertStringContainsString('fa fa-sliders', $markup);
+        $this->assertStringNotContainsString('fa fa-cog', $markup);
+    }
+}

--- a/tests/Unit/ResourcesOverviewMarkupTest.php
+++ b/tests/Unit/ResourcesOverviewMarkupTest.php
@@ -8,7 +8,7 @@ class ResourcesOverviewMarkupTest extends TestCase
 {
     public function testDominionSettingsButtonIsSeparatedFromTheDominionName(): void
     {
-        $markup = file_get_contents(__DIR__.'/../../app/resources/views/partials/resources-overview.blade.php');
+        $markup = file_get_contents(__DIR__ . '/../../app/resources/views/partials/resources-overview.blade.php');
 
         $titlePosition = strpos($markup, '<span class="card-title flex-grow-1">');
         $settingsButtonPosition = strpos($markup, '<a class="btn btn-sm btn-outline-secondary flex-shrink-0 dominion-settings-button"');


### PR DESCRIPTION
## Summary

- replace the icon-only cog beside the dominion name with a compact settings button
- move the control to the top-right of the resource overview card
- use a sliders icon and responsive label while retaining an accessible name on mobile
- add a focused unit test for the layout and accessibility markup

## Why

The old cog appeared directly beside the dominion name, making the header feel cramped and leaving the action’s purpose unclear. Positioning a labeled secondary control at the card’s trailing edge gives the overview title and dominion name their own visual space while making the settings action easier to identify.

## Validation

- `php artisan test --compact tests/Unit/ResourcesOverviewMarkupTest.php`
- `npm run build`
- desktop and 375px mobile visual checks
