### PR TITLE
Warn when beneficial spells are expiring

### DIFF
--- a/app/resources/views/partials/main-sidebar.blade.php
+++ b/app/resources/views/partials/main-sidebar.blade.php
@@ -203,6 +203,9 @@
                         <a href="{{ route('dominion.magic') }}" class="nav-link {{ Route::is('dominion.magic') ? 'active' : null }}">
                             <i class="nav-icon ra ra-fairy-wand ra-fw"></i>
                             <p>Magic
+                                @if ($expiringBeneficialSpells > 0)
+                                    <span class="badge text-bg-warning" title="Beneficial spells expiring next tick">{{ $expiringBeneficialSpells }}</span>
+                                @endif
                                 @if ($activeSelfSpells > 0)
                                     <span class="badge text-bg-info">{{ $activeSelfSpells }}</span>
                                 @endif

--- a/src/Providers/ComposerServiceProvider.php
+++ b/src/Providers/ComposerServiceProvider.php
@@ -69,13 +69,19 @@ class ComposerServiceProvider extends AbstractServiceProvider
                 ->count();
             $view->with('forumUnreadCount', $forumUnreadCount);
 
-            $activeSelfSpells = $selectedDominion->spells->where('category', 'self')->count();
+            $expiringBeneficialSpells = $selectedDominion->spells->filter(function ($spell) {
+                return !$spell->isHarmful() && (int) $spell->pivot->duration === 1;
+            })->count();
+            $activeSelfSpells = $selectedDominion->spells->filter(function ($spell) {
+                return $spell->category === 'self' && (int) $spell->pivot->duration > 1;
+            })->count();
             $activeHostileSpells = $selectedDominion->spells->filter(function ($spell) {
                 return $spell->isHarmful();
             })->count();
             $activeFriendlySpells = $selectedDominion->spells->filter(function ($spell) {
-                return !$spell->isHarmful() && $spell->category !== 'self';
+                return !$spell->isHarmful() && $spell->category !== 'self' && (int) $spell->pivot->duration > 1;
             })->count();
+            $view->with('expiringBeneficialSpells', $expiringBeneficialSpells);
             $view->with('activeSelfSpells', $activeSelfSpells);
             $view->with('activeHostileSpells', $activeHostileSpells);
             $view->with('activeFriendlySpells', $activeFriendlySpells);

--- a/tests/Feature/Http/Dominion/MagicSidebarTest.php
+++ b/tests/Feature/Http/Dominion/MagicSidebarTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace OpenDominion\Tests\Feature\Http\Dominion;
+
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use OpenDominion\Models\DominionSpell;
+use OpenDominion\Models\Spell;
+use OpenDominion\Tests\AbstractTestCase;
+
+class MagicSidebarTest extends AbstractTestCase
+{
+    use DatabaseTransactions;
+
+    public function testExpiringBeneficialSpellsUseASeparateWarningBadge(): void
+    {
+        $user = $this->createAndImpersonateUser();
+        $round = $this->createRound();
+        $dominion = $this->createDominion($user, $round);
+
+        foreach (['ares_call' => 1, 'midas_touch' => 12] as $spellKey => $duration) {
+            DominionSpell::create([
+                'dominion_id' => $dominion->id,
+                'spell_id' => Spell::where('key', $spellKey)->value('id'),
+                'duration' => $duration,
+                'cast_by_dominion_id' => $dominion->id,
+            ]);
+        }
+
+        $this->selectDominion($dominion->fresh());
+
+        $response = $this->get('/dominion/status');
+
+        $response
+            ->assertOk()
+            ->assertSee('<span class="badge text-bg-warning" title="Beneficial spells expiring next tick">1</span>', false)
+            ->assertSee('<span class="badge text-bg-info">1</span>', false);
+    }
+}


### PR DESCRIPTION
## Summary

The Magic sidebar previously counted all active self and friendly spells together regardless of their remaining duration. Players therefore had to open the Magic Advisor to notice that a beneficial spell such as Ares' Call would expire on the next tick.

This change separates beneficial spells with exactly one tick remaining into a yellow warning badge. Longer-lived self spells remain blue, longer-lived friendly spells remain green, and hostile spells remain red. For three self spells with one expiring plus four hostile spells, the sidebar now renders yellow `1`, blue `2`, red `4`.

## Validation

- Added an HTTP feature test covering one-tick Ares' Call alongside a longer-lived self spell.
- Ran `php artisan test --compact tests/Feature/Http/Dominion/MagicSidebarTest.php` in the project container: 1 test passed, 3 assertions.
- Rendered the changed sidebar using the repository's compiled theme and icon assets; browser console reported zero errors or warnings.
