### PR TITLE
Preview Cyclone damage on wonders

### DIFF
--- a/app/resources/views/pages/dominion/wonders.blade.php
+++ b/app/resources/views/pages/dominion/wonders.blade.php
@@ -94,7 +94,9 @@
                                         <option></option>
                                         @foreach ($wonders as $wonder)
                                             @if ($wonder->realm == null || $governmentService->canAttackWonders($selectedDominion->realm, $wonder->realm))
-                                                <option value="{{ $wonder->id }}" data-war="{{ $wonder->realm !== null ? 1 : 0 }}">
+                                                <option value="{{ $wonder->id }}"
+                                                        data-war="{{ $wonder->realm !== null ? 1 : 0 }}"
+                                                        data-cyclone-damage="{{ $cycloneDamageByWonder[$wonder->id] }}">
                                                     {{ $wonder->wonder->name }}
                                                     @if ($wonder->realm !== null)
                                                         (#{{ $wonder->realm->number }})
@@ -103,6 +105,10 @@
                                             @endif
                                         @endforeach
                                     </select>
+                                    <div class="small mt-2">
+                                        Current Cyclone damage:
+                                        <strong id="cyclone-damage" aria-live="polite">Select a target</strong>
+                                    </div>
                                 </div>
                                 <div class="col-3 col-lg-2">
                                     @foreach ($spellHelper->getSpells(null, 'wonder') as $spell)
@@ -373,6 +379,7 @@
 
             var invadeButtonElement = $('#attack-button');
             var allUnitInputs = $('input[name^=\'unit\']');
+            var cycloneDamageElement = $('#cyclone-damage');
 
             $('#target_wonder').select2({
                 templateResult: select2Template,
@@ -381,10 +388,12 @@
 
             @if (!$protectionService->isUnderProtection($selectedDominion))
                 updateUnitStats();
+                updateCycloneDamage();
             @endif
 
             $('#target_wonder').change(function (e) {
                 updateUnitStats();
+                updateCycloneDamage();
             });
 
             $('input[name^=\'calc\']').change(function (e) {
@@ -435,6 +444,17 @@
                         }
                     }
                 );
+            }
+
+            function updateCycloneDamage() {
+                var cycloneDamage = $('#target_wonder option:selected').attr('data-cyclone-damage');
+
+                if (cycloneDamage === undefined) {
+                    cycloneDamageElement.text('Select a target');
+                    return;
+                }
+
+                cycloneDamageElement.text(parseInt(cycloneDamage).toLocaleString());
             }
 
             function calculate() {

--- a/docs/claude/CALCULATORS.md
+++ b/docs/claude/CALCULATORS.md
@@ -48,7 +48,8 @@ Round-end valor rankings.
 Wonder combat mechanics.
 - `PRESTIGE_BASE_GAIN` = 25, `PRESTIGE_CONTRIBUTION_MULTIPLIER` = 50
 - `MIN_SPAWN_POWER` = 150000, `MAX_SPAWN_POWER` = 500000
-- Methods: `getCurrentPower()`, `getDamageDealt()`, `getPrestigeGainForDominion()`
+- Methods: `getCurrentPower()`, `getDamageDealt()`, `getCycloneDamage()`, `getPrestigeGainForDominion()`
+- Cyclone damage includes wonder-damage tech, Cyclone hero perks, neutral-wonder doubling, and the per-wonder power cap.
 
 ### RaidCalculator
 Raid scoring, objectives, rewards, leaderboards.

--- a/src/Calculators/WonderCalculator.php
+++ b/src/Calculators/WonderCalculator.php
@@ -3,6 +3,7 @@
 namespace OpenDominion\Calculators;
 
 use OpenDominion\Calculators\Dominion\LandCalculator;
+use OpenDominion\Calculators\Dominion\MilitaryCalculator;
 use OpenDominion\Models\Dominion;
 use OpenDominion\Models\Realm;
 use OpenDominion\Models\RoundWonder;
@@ -10,6 +11,16 @@ use OpenDominion\Models\Wonder;
 
 class WonderCalculator
 {
+    /**
+     * @var float Base percentage for Cyclone damage cap
+     */
+    protected const CYCLONE_DAMAGE_CAP_PERCENTAGE = 0.75;
+
+    /**
+     * @var float Wizard multiplier for Cyclone damage
+     */
+    protected const CYCLONE_DAMAGE_MULTIPLIER = 1.5;
+
     /**
      * @var float Base gain for dominions over the minimum threshold
      */
@@ -39,6 +50,41 @@ class WonderCalculator
      * @var float Maximum power after a neutral wonder is respawned
      */
     protected const MAX_SPAWN_POWER = 500000;
+
+    public function __construct(
+        protected LandCalculator $landCalculator,
+        protected MilitaryCalculator $militaryCalculator
+    )
+    {
+    }
+
+    /**
+     * Returns the damage a Cyclone cast would deal to a wonder.
+     *
+     * @param Dominion $dominion
+     * @param RoundWonder $wonder
+     * @return int
+     */
+    public function getCycloneDamage(Dominion $dominion, RoundWonder $wonder): int
+    {
+        $wizardRatio = min(1, $this->militaryCalculator->getWizardRatioRaw($dominion));
+        $damage = static::CYCLONE_DAMAGE_MULTIPLIER * $wizardRatio * $this->landCalculator->getTotalLand($dominion);
+
+        $multiplier = 1 + $dominion->getTechPerkMultiplier('wonder_damage');
+        if ($dominion->hero !== null) {
+            $multiplier += $dominion->hero->getPerkMultiplier('cyclone_damage');
+        }
+
+        $damage *= $multiplier;
+
+        if ($wonder->realm_id === null) {
+            $damage *= 2;
+        }
+
+        $damageCap = $wonder->power * (static::CYCLONE_DAMAGE_CAP_PERCENTAGE / 100);
+
+        return (int) round(min($damage, $damageCap));
+    }
 
     /**
      * Returns the wonder's power when being rebuilt.
@@ -136,7 +182,7 @@ class WonderCalculator
     * @param string $source
     * @return float
     */
-    public function getDamageDealtByDominion(RoundWonder $wonder, Dominion $dominion, string $source = null): float
+    public function getDamageDealtByDominion(RoundWonder $wonder, Dominion $dominion, ?string $source = null): float
     {
         $wonderDamage = $wonder->damage()->where('dominion_id', $dominion->id);
         if ($source !== null) {

--- a/src/Http/Controllers/Dominion/WonderController.php
+++ b/src/Http/Controllers/Dominion/WonderController.php
@@ -36,14 +36,20 @@ class WonderController extends AbstractDominionController
             ->get()
             ->sortBy('wonder.name');
 
+        $wonderCalculator = app(WonderCalculator::class);
+        $cycloneDamageByWonder = $wonders->mapWithKeys(function (RoundWonder $wonder) use ($dominion, $wonderCalculator) {
+            return [$wonder->id => $wonderCalculator->getCycloneDamage($dominion, $wonder)];
+        });
+
         return view('pages.dominion.wonders', [
+            'cycloneDamageByWonder' => $cycloneDamageByWonder,
             'governmentService' => app(GovernmentService::class),
             'militaryCalculator' => app(MilitaryCalculator::class),
             'protectionService' => app(ProtectionService::class),
             'spellCalculator' => app(SpellCalculator::class),
             'spellHelper' => app(SpellHelper::class),
             'unitHelper' => app(UnitHelper::class),
-            'wonderCalculator' => app(WonderCalculator::class),
+            'wonderCalculator' => $wonderCalculator,
             'wonderHelper' => app(WonderHelper::class),
             'wonders' => $wonders,
         ]);

--- a/src/Services/Dominion/Actions/WonderActionService.php
+++ b/src/Services/Dominion/Actions/WonderActionService.php
@@ -39,16 +39,6 @@ class WonderActionService
      */
     protected const CASUALTIES_BASE_PERCENTAGE = 3.5;
 
-    /**
-     * @var float Base percentage for cyclone damage cap
-     */
-    protected const CYCLONE_DAMAGE_CAP_PERCENTAGE = 0.75;
-
-    /**
-     * @var float Wizard multiplier for cyclone damage
-     */
-    protected const CYCLONE_DAMAGE_MULTIPLIER = 1.5;
-
     /** @var GovernmentService */
     protected $governmentService;
 
@@ -227,29 +217,7 @@ class WonderActionService
             $dominion->wizard_strength -= 5;
             $dominion->stat_spell_success += 1;
 
-            $wizardRatio = min(1, $this->militaryCalculator->getWizardRatioRaw($dominion));
-            $damageDealt = static::CYCLONE_DAMAGE_MULTIPLIER * $wizardRatio * $this->landCalculator->getTotalLand($dominion);
-            $damageCap = static::CYCLONE_DAMAGE_CAP_PERCENTAGE / 100;
-
-            $multiplier = 1;
-
-            // Techs
-            $multiplier += $dominion->getTechPerkMultiplier('wonder_damage');
-
-            // Heroes
-            if ($dominion->hero !== null) {
-                $multiplier += $dominion->hero->getPerkMultiplier('cyclone_damage');
-            }
-
-            $damageDealt *= $multiplier;
-
-            // Double damage if neutral wonder
-            if ($this->attackResult['wonder']['neutral']) {
-                $damageDealt *= 2;
-            }
-
-            // Cap at % of wonder max power
-            $damageDealt = round(min($damageDealt, $wonder->power * $damageCap));
+            $damageDealt = $this->wonderCalculator->getCycloneDamage($dominion, $wonder);
             $dominion->stat_cyclone_damage += $damageDealt;
 
             $wonderPower = max(0, $this->wonderCalculator->getCurrentPower($wonder) - $damageDealt);

--- a/src/Services/Dominion/Actions/WonderActionService.php
+++ b/src/Services/Dominion/Actions/WonderActionService.php
@@ -4,7 +4,6 @@ namespace OpenDominion\Services\Dominion\Actions;
 
 use DB;
 use LogicException;
-use OpenDominion\Calculators\Dominion\LandCalculator;
 use OpenDominion\Calculators\Dominion\MilitaryCalculator;
 use OpenDominion\Calculators\Dominion\OpsCalculator;
 use OpenDominion\Calculators\Dominion\SpellCalculator;
@@ -47,9 +46,6 @@ class WonderActionService
 
     /** @var InvasionService */
     protected $invasionService;
-
-    /** @var LandCalculator */
-    protected $landCalculator;
 
     /** @var MilitaryCalculator */
     protected $militaryCalculator;
@@ -107,7 +103,6 @@ class WonderActionService
      * @param GovernmentService $governmentService
      * @param GuardMembershipService $guardMembershipService
      * @param InvasionService $invasionService
-     * @param LandCalculator $landCalculator
      * @param MilitaryCalculator $militaryCalculator
      * @param NotificationService $notificationService
      * @param OpsCalculator $opsCalculator
@@ -122,7 +117,6 @@ class WonderActionService
         GovernmentService $governmentService,
         GuardMembershipService $guardMembershipService,
         InvasionService $invasionService,
-        LandCalculator $landCalculator,
         MilitaryCalculator $militaryCalculator,
         NotificationService $notificationService,
         OpsCalculator $opsCalculator,
@@ -137,7 +131,6 @@ class WonderActionService
         $this->governmentService = $governmentService;
         $this->guardMembershipService = $guardMembershipService;
         $this->invasionService = $invasionService;
-        $this->landCalculator = $landCalculator;
         $this->militaryCalculator = $militaryCalculator;
         $this->notificationService = $notificationService;
         $this->opsCalculator = $opsCalculator;

--- a/tests/Feature/Http/Dominion/WonderCyclonePreviewTest.php
+++ b/tests/Feature/Http/Dominion/WonderCyclonePreviewTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace OpenDominion\Tests\Feature\Http\Dominion;
+
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use OpenDominion\Models\RoundWonder;
+use OpenDominion\Models\Wonder;
+use OpenDominion\Tests\AbstractTestCase;
+
+class WonderCyclonePreviewTest extends AbstractTestCase
+{
+    use DatabaseTransactions;
+
+    public function testWondersPageIncludesCycloneDamageForEachTarget(): void
+    {
+        $user = $this->createAndImpersonateUser();
+        $round = $this->createRound('-4 days midnight');
+        $dominion = $this->createAndSelectDominionWithLegacyStats($user, $round);
+        $wonder = Wonder::where('key', 'urg')->firstOrFail();
+
+        RoundWonder::create([
+            'round_id' => $round->id,
+            'wonder_id' => $wonder->id,
+            'power' => 500000,
+        ]);
+
+        $response = $this->get(route('dominion.wonders'));
+
+        $response
+            ->assertOk()
+            ->assertSee('Current Cyclone damage:')
+            ->assertSee('data-cyclone-damage="75"', false)
+            ->assertSee('id="cyclone-damage" aria-live="polite"', false);
+    }
+}

--- a/tests/Unit/Calculators/WonderCalculatorTest.php
+++ b/tests/Unit/Calculators/WonderCalculatorTest.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace OpenDominion\Tests\Unit\Calculators;
+
+use Mockery as m;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use OpenDominion\Calculators\Dominion\LandCalculator;
+use OpenDominion\Calculators\Dominion\MilitaryCalculator;
+use OpenDominion\Calculators\WonderCalculator;
+use OpenDominion\Models\Dominion;
+use OpenDominion\Models\Hero;
+use OpenDominion\Models\RoundWonder;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(WonderCalculator::class)]
+class WonderCalculatorTest extends TestCase
+{
+    use MockeryPHPUnitIntegration;
+
+    public function testGetCycloneDamageAppliesTechHeroAndNeutralWonderModifiers(): void
+    {
+        $dominion = m::mock(Dominion::class);
+        $hero = m::mock(Hero::class);
+        $wonder = m::mock(RoundWonder::class);
+
+        $dominion->shouldReceive('getTechPerkMultiplier')->with('wonder_damage')->andReturn(0.2);
+        $dominion->shouldReceive('getAttribute')->with('hero')->andReturn($hero);
+        $hero->shouldReceive('getPerkMultiplier')->with('cyclone_damage')->andReturn(0.1);
+        $wonder->shouldReceive('getAttribute')->with('realm_id')->andReturn(null);
+        $wonder->shouldReceive('getAttribute')->with('power')->andReturn(1000000);
+
+        $calculator = $this->makeCalculator($dominion, 0.5, 1000);
+
+        $this->assertSame(1950, $calculator->getCycloneDamage($dominion, $wonder));
+    }
+
+    public function testGetCycloneDamageDoesNotDoubleDamageForOwnedWonder(): void
+    {
+        $dominion = m::mock(Dominion::class);
+        $wonder = m::mock(RoundWonder::class);
+
+        $dominion->shouldReceive('getTechPerkMultiplier')->with('wonder_damage')->andReturn(0.2);
+        $dominion->shouldReceive('getAttribute')->with('hero')->andReturn(null);
+        $wonder->shouldReceive('getAttribute')->with('realm_id')->andReturn(123);
+        $wonder->shouldReceive('getAttribute')->with('power')->andReturn(1000000);
+
+        $calculator = $this->makeCalculator($dominion, 0.5, 1000);
+
+        $this->assertSame(900, $calculator->getCycloneDamage($dominion, $wonder));
+    }
+
+    public function testGetCycloneDamageRespectsWonderPowerCap(): void
+    {
+        $dominion = m::mock(Dominion::class);
+        $wonder = m::mock(RoundWonder::class);
+
+        $dominion->shouldReceive('getTechPerkMultiplier')->with('wonder_damage')->andReturn(0.0);
+        $dominion->shouldReceive('getAttribute')->with('hero')->andReturn(null);
+        $wonder->shouldReceive('getAttribute')->with('realm_id')->andReturn(null);
+        $wonder->shouldReceive('getAttribute')->with('power')->andReturn(100000);
+
+        $calculator = $this->makeCalculator($dominion, 1.0, 1000);
+
+        $this->assertSame(750, $calculator->getCycloneDamage($dominion, $wonder));
+    }
+
+    private function makeCalculator(Dominion $dominion, float $wizardRatio, int $land): WonderCalculator
+    {
+        $landCalculator = m::mock(LandCalculator::class);
+        $militaryCalculator = m::mock(MilitaryCalculator::class);
+
+        $landCalculator->shouldReceive('getTotalLand')->with($dominion)->andReturn($land);
+        $militaryCalculator->shouldReceive('getWizardRatioRaw')->with($dominion)->andReturn($wizardRatio);
+
+        return new WonderCalculator($landCalculator, $militaryCalculator);
+    }
+}

--- a/tests/Unit/Calculators/WonderCalculatorTest.php
+++ b/tests/Unit/Calculators/WonderCalculatorTest.php
@@ -2,8 +2,8 @@
 
 namespace OpenDominion\Tests\Unit\Calculators;
 
-use Mockery as m;
 use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use Mockery as m;
 use OpenDominion\Calculators\Dominion\LandCalculator;
 use OpenDominion\Calculators\Dominion\MilitaryCalculator;
 use OpenDominion\Calculators\WonderCalculator;


### PR DESCRIPTION
## Summary

Players currently have to calculate Cyclone damage by hand before attacking a wonder, and the simple wizard/acre formula does not account for every modifier applied by the server.

This change moves Cyclone damage into `WonderCalculator` as the shared source of truth for both casts and previews. The calculation includes wonder-damage tech, Cyclone hero perks, neutral-wonder double damage, and the per-wonder power cap. The wonders attack card exposes the calculated value for each eligible target and updates the displayed damage immediately when the selected wonder changes.

## Validation

- `docker compose exec -T app php artisan test --compact tests/Unit/Calculators/WonderCalculatorTest.php tests/Feature/Http/Dominion/WonderCyclonePreviewTest.php` — 4 tests passed, 7 assertions
- PHP syntax checks passed for all changed PHP files
- `git diff --check` passed
- Verified in a real browser at desktop width by selecting a seeded wonder and confirming the preview updated to the calculated damage
