### PR TITLE
[codex] Add sticky Ops Center report navigation

### DIFF
--- a/app/resources/sass/app.scss
+++ b/app/resources/sass/app.scss
@@ -104,6 +104,26 @@ a {
   white-space: nowrap;
 }
 
+// ─── Op Center report navigation ────────────────────────────────────────────
+
+.op-center-navigation {
+  position: sticky;
+  top: 0.5rem;
+  z-index: $zindex-sticky;
+}
+
+.op-center-navigation-scroller {
+  min-width: 0;
+  overflow-x: auto;
+  padding-bottom: 0.125rem;
+  scrollbar-color: var(--bs-border-color) transparent;
+  scrollbar-width: thin;
+}
+
+.op-center-report-anchor {
+  scroll-margin-top: 4.75rem;
+}
+
 // ─── Custom App Styles ────────────────────────────────────────────────────────
 
 @media (min-width: 768px) {

--- a/app/resources/views/pages/dominion/op-center/show.blade.php
+++ b/app/resources/views/pages/dominion/op-center/show.blade.php
@@ -88,7 +88,10 @@
     @if ($inRealm)
         @include('partials.dominion.advisor-selector')
     @endif
-    <div class="row">
+
+    @include('partials.dominion.op-center.navigation')
+
+    <div class="row op-center-report-anchor" id="op-clear-sight">
         <div class="col-sm-12 col-md-9">
             @component('partials.dominion.op-center.box')
                 @slot('title', ('Status Screen - ' . $dominion->name . ' (#' . $dominion->realm->number . ')'))
@@ -277,7 +280,7 @@
         </div>
 
     </div>
-    <div class="row">
+    <div class="row op-center-report-anchor" id="op-revelation">
 
         <div class="col-sm-12 col-md-6">
             @component('partials.dominion.op-center.box')
@@ -392,7 +395,7 @@
             @endcomponent
         </div>
 
-        <div class="col-sm-12 col-md-6">
+        <div class="col-sm-12 col-md-6 op-center-report-anchor" id="op-castle-spy">
             @component('partials.dominion.op-center.box')
                 @slot('title', 'Improvements')
                 @slot('titleIconClass', 'fa fa-arrow-up')
@@ -454,7 +457,7 @@
         </div>
 
     </div>
-    <div class="row">
+    <div class="row op-center-report-anchor" id="op-barracks-spy">
 
         <div class="col-sm-12 col-md-6">
             @component('partials.dominion.op-center.box')
@@ -533,7 +536,7 @@
         </div>
 
     </div>
-    <div class="row">
+    <div class="row op-center-report-anchor" id="op-survey-dominion">
 
         <div class="col-sm-12 col-md-6">
             @component('partials.dominion.op-center.box')
@@ -616,7 +619,7 @@
         </div>
 
     </div>
-    <div class="row">
+    <div class="row op-center-report-anchor" id="op-land-spy">
 
         <div class="col-sm-12 col-md-6">
             @component('partials.dominion.op-center.box')
@@ -696,7 +699,7 @@
         </div>
 
     </div>
-    <div class="row">
+    <div class="row op-center-report-anchor" id="op-vision">
 
         <div class="col-sm-12 col-md-6">
             @component('partials.dominion.op-center.box')
@@ -777,7 +780,7 @@
         </div>
 
     </div>
-    <div class="row">
+    <div class="row op-center-report-anchor" id="op-disclosure">
 
         <div class="col-sm-12 col-md-6">
             @component('partials.dominion.op-center.box')

--- a/app/resources/views/partials/dominion/op-center/navigation.blade.php
+++ b/app/resources/views/partials/dominion/op-center/navigation.blade.php
@@ -1,0 +1,21 @@
+<nav class="op-center-navigation card shadow-sm mb-3" aria-label="Jump to an information operation">
+    <div class="card-body d-flex align-items-center gap-2 p-2">
+        <span class="text-body-secondary text-nowrap" aria-hidden="true">
+            <i class="fa fa-binoculars me-sm-1"></i>
+            <span class="d-none d-sm-inline">Jump to</span>
+        </span>
+
+        <div class="op-center-navigation-scroller">
+            <div class="d-flex gap-2">
+                <a class="btn btn-sm btn-outline-primary" href="#op-clear-sight">Clear Sight</a>
+                <a class="btn btn-sm btn-outline-primary" href="#op-revelation">Revelation</a>
+                <a class="btn btn-sm btn-outline-primary" href="#op-castle-spy">Castle Spy</a>
+                <a class="btn btn-sm btn-outline-primary" href="#op-barracks-spy">Barracks Spy</a>
+                <a class="btn btn-sm btn-outline-primary" href="#op-survey-dominion">Survey Dominion</a>
+                <a class="btn btn-sm btn-outline-primary" href="#op-land-spy">Land Spy</a>
+                <a class="btn btn-sm btn-outline-primary" href="#op-vision">Vision</a>
+                <a class="btn btn-sm btn-outline-primary" href="#op-disclosure">Disclosure</a>
+            </div>
+        </div>
+    </div>
+</nav>

--- a/tests/Feature/Http/Dominion/OpCenterNavigationTest.php
+++ b/tests/Feature/Http/Dominion/OpCenterNavigationTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace OpenDominion\Tests\Feature\Http\Dominion;
+
+use OpenDominion\Tests\AbstractTestCase;
+
+class OpCenterNavigationTest extends AbstractTestCase
+{
+    public function testNavigationLinksToEveryInformationOperationSection(): void
+    {
+        $html = view('partials.dominion.op-center.navigation')->render();
+        $opCenterView = file_get_contents(resource_path('views/pages/dominion/op-center/show.blade.php'));
+
+        $this->assertIsString($opCenterView);
+        $this->assertStringContainsString("@include('partials.dominion.op-center.navigation')", $opCenterView);
+
+        $expectedOperations = [
+            'op-clear-sight' => 'Clear Sight',
+            'op-revelation' => 'Revelation',
+            'op-castle-spy' => 'Castle Spy',
+            'op-barracks-spy' => 'Barracks Spy',
+            'op-survey-dominion' => 'Survey Dominion',
+            'op-land-spy' => 'Land Spy',
+            'op-vision' => 'Vision',
+            'op-disclosure' => 'Disclosure',
+        ];
+
+        foreach ($expectedOperations as $anchor => $label) {
+            $this->assertStringContainsString('href="#' . $anchor . '"', $html);
+            $this->assertStringContainsString('>' . $label . '</a>', $html);
+            $this->assertStringContainsString('id="' . $anchor . '"', $opCenterView);
+        }
+
+        $this->assertSame(count($expectedOperations), substr_count($html, 'btn-outline-primary'));
+    }
+}


### PR DESCRIPTION
## Summary

Players reviewing a dominion's Ops Center currently have to scroll through a long report page to move between information operations. The page has no in-page index, so checking an older section such as Survey Dominion and then switching to Castle Spy requires manually finding the next report.

This adds a compact, sticky report navigation bar to the dominion Ops Center. It covers all eight information operations: Clear Sight, Revelation, Castle Spy, Barracks Spy, Survey Dominion, Land Spy, Vision, and Disclosure. Each control jumps to the first section populated by that op, including ops that power paired report cards.

The navigation uses the existing Bootstrap card and button system so it inherits every OpenDominion theme. On narrow screens, the controls stay on one line in a horizontally scrollable region rather than wrapping into a tall toolbar. Report anchors include scroll clearance so headings remain visible beneath the sticky bar.

## Validation

- `php artisan test --compact tests/Feature/Http/Dominion/OpCenterNavigationTest.php`
- `php artisan view:cache`
- `npm run build`
- Browser-verified at 1600px and 390px widths
- Browser-verified anchor navigation and sticky behavior using Survey Dominion
- Browser-verified in the default light theme and the Grimoire dark theme
