### PR TITLE
Match realm-assignment feedback by user ID

### DIFF
--- a/docs/claude/SERVICES.md
+++ b/docs/claude/SERVICES.md
@@ -124,7 +124,7 @@ Daily ranking snapshots by category (land, networth, conquered, explored, etc.).
 ### RealmAssignmentService (largest service)
 Sophisticated pre-round realm assignment algorithm.
 - Constants: `MAX_PACKS_PER_REALM` = 3, `MAX_PACKED_PLAYERS_PER_REALM` = 8, realms 8-14
-- Uses nested classes: Player, PlaceholderPack, PlaceholderRealm
+- Uses nested classes: Player, PlaceholderPack, PlaceholderRealm; Player keeps distinct dominion and user IDs so feedback matches users
 - Scoring: compatibility (favorability + playstyle balance) + rating deviation + size bonus
 - Optimization: 50 iterations of random solo-player swapping
 

--- a/src/Services/RealmAssignmentService.php
+++ b/src/Services/RealmAssignmentService.php
@@ -19,10 +19,11 @@ use OpenDominion\Services\NotificationService;
 class Player
 {
     public string $id;
+    public string $userId;
     public float $rating;
     public ?string $packId;
     public bool $hasDiscord = true;
-    public array $favorability = []; // player_id => score
+    public array $favorability = []; // user_id => score
 
     // Playstyle affinities (0-100 for each category)
     public float $attackerAffinity = 0;
@@ -45,6 +46,10 @@ class Player
                 $this->$key = $value;
             }
         }
+
+        if (!isset($this->userId)) {
+            $this->userId = $this->id;
+        }
     }
 
     /**
@@ -54,12 +59,12 @@ class Player
      * Positive values indicate endorsement, negative values indicate negative feedback.
      * Returns 0 if no feedback has been given.
      *
-     * @param string $playerId The ID of the other player
+     * @param string $userId The user ID of the other player
      * @return float Favorability score (-1 to 1, typically)
      */
-    public function getFavorabilityWith(string $playerId): float
+    public function getFavorabilityWith(string $userId): float
     {
-        return $this->favorability[$playerId] ?? 0;
+        return $this->favorability[$userId] ?? 0;
     }
 
     /**
@@ -130,8 +135,8 @@ class PlaceholderPack
 
         foreach ($this->members as $member1) {
             foreach ($pack->members as $member2) {
-                $totalScore += $member1->getFavorabilityWith($member2->id);
-                $totalScore += $member2->getFavorabilityWith($member1->id);
+                $totalScore += $member1->getFavorabilityWith($member2->userId);
+                $totalScore += $member2->getFavorabilityWith($member1->userId);
             }
         }
 
@@ -312,8 +317,8 @@ class PlaceholderRealm
         foreach ($players as $newMember) {
             $favorabilityScore = 0;
             foreach ($this->players as $realmMember) {
-                $favorabilityScore += $realmMember->getFavorabilityWith($newMember->id);
-                $favorabilityScore += $newMember->getFavorabilityWith($realmMember->id);
+                $favorabilityScore += $realmMember->getFavorabilityWith($newMember->userId);
+                $favorabilityScore += $newMember->getFavorabilityWith($realmMember->userId);
             }
             if ($favorabilityScore < -10) {
                 // Heavy penalty for conflicts
@@ -597,6 +602,7 @@ class RealmAssignmentService
             // Create player
             $player = new Player([
                 'id' => $dominion->id,
+                'userId' => $dominion->user_id,
                 'packId' => $dominion->pack_id,
                 'rating' => $dominion->user->rating ?? 0,
                 'favorability' => $favorabilityMatrix,
@@ -1571,6 +1577,7 @@ class RealmAssignmentService
 
         return new Player([
             'id' => $user->id,
+            'userId' => $user->id,
             'packId' => null, // Individual registration
             'rating' => $user->rating ?? 0,
             'favorability' => $favorabilityMatrix,
@@ -1622,6 +1629,7 @@ class RealmAssignmentService
         $players = $realm->dominions()->human()->get()->map(function ($dominion) {
             return new Player([
                 'id' => $dominion->user_id,
+                'userId' => $dominion->user_id,
                 'packId' => $dominion->pack_id,
                 'rating' => $dominion->user->rating ?? 0,
                 'favorability' => [], // Not needed for existing players in this context

--- a/tests/Unit/Services/RealmAssignmentServiceTest.php
+++ b/tests/Unit/Services/RealmAssignmentServiceTest.php
@@ -1219,6 +1219,32 @@ class RealmAssignmentServiceTest extends AbstractTestCase
         echo 'Worse composition deviation: ' . round($worseDeviation, 2) . "\n";
     }
 
+    public function testCompatibilityMatchesFeedbackByUserId(): void
+    {
+        $realmMember = new Player([
+            'id' => 'dominion-101',
+            'userId' => 'user-1',
+            'rating' => 1500,
+            'favorability' => ['user-2' => 2],
+        ]);
+        $incomingPlayer = new Player([
+            'id' => 'dominion-202',
+            'userId' => 'user-2',
+            'rating' => 1500,
+            'favorability' => ['user-1' => 3],
+        ]);
+        $realm = new PlaceholderRealm('test', collect([$realmMember]));
+
+        $compatibilityScore = $realm->getCompatibilityScore(collect([$incomingPlayer]));
+        $playstyleScore = $realm->calculatePlaystyleScore(collect([$incomingPlayer]));
+
+        $this->assertEquals(
+            5,
+            $compatibilityScore - $playstyleScore,
+            'Feedback should match user IDs even when dominion IDs differ'
+        );
+    }
+
     /**
      * Test that new playstyle scoring properly distinguishes balanced vs imbalanced compositions
      */


### PR DESCRIPTION
## Summary

Assignment feedback is stored by user ID, while the pre-round assignment `Player::id` field contains a dominion ID. Compatibility calculations used that dominion ID to query the feedback matrices, so feedback usually had no effect and could be attributed to the wrong player when unrelated numeric IDs happened to collide.

This change keeps separate assignment/persistence and feedback identities on `Player`: `id` remains the dominion ID, while `userId` is used for favorability lookups. Bulk and late-assignment construction paths now set that identity explicitly, with a backwards-compatible default for existing fixtures. A regression test uses deliberately different dominion and user IDs and verifies the bidirectional feedback score.

## User impact

Historical endorsements and dislikes now influence pre-round realm assignment for the users who actually submitted and received them.

## Verification

- Added focused regression coverage for user-ID feedback matching.
- Passed the pure realm-assignment/feedback test subset: 6 tests, 158 assertions.
- Passed PHP syntax checks and `git diff --check`.
