### PR TITLE
Test non-Discord pack assignment ordering

### DIFF
--- a/docs/claude/GAME_SYSTEMS.md
+++ b/docs/claude/GAME_SYSTEMS.md
@@ -189,7 +189,7 @@ Pre-round player distribution (RealmAssignmentService):
 2. Load players with ratings and favorability data
 3. Calculate realm count (8-14) based on large pack distribution
 4. Place large packs as realm seeds
-5. Segregate non-Discord players (preference-based)
+5. Segregate non-Discord solo players (packed players remain with their packs)
 6. Assign remaining packs by compatibility scoring
 7. Fill solos by rating balance + playstyle diversity
 8. Optimize via 50 iterations of random swap improvement

--- a/src/Services/RealmAssignmentService.php
+++ b/src/Services/RealmAssignmentService.php
@@ -755,9 +755,7 @@ class RealmAssignmentService
      */
     public function createNonDiscordRealms(): void
     {
-        $nonDiscordSoloPlayers = $this->players
-            ->where('hasDiscord', false)
-            ->where('packId', null);
+        $nonDiscordSoloPlayers = $this->players->where('hasDiscord', false);
         $totalNonDiscordPlayers = $nonDiscordSoloPlayers->count();
 
         if ($totalNonDiscordPlayers === 0) {

--- a/src/Services/RealmAssignmentService.php
+++ b/src/Services/RealmAssignmentService.php
@@ -755,7 +755,9 @@ class RealmAssignmentService
      */
     public function createNonDiscordRealms(): void
     {
-        $nonDiscordSoloPlayers = $this->players->where('hasDiscord', false);
+        $nonDiscordSoloPlayers = $this->players
+            ->where('hasDiscord', false)
+            ->where('packId', null);
         $totalNonDiscordPlayers = $nonDiscordSoloPlayers->count();
 
         if ($totalNonDiscordPlayers === 0) {

--- a/tests/Unit/Services/RealmAssignmentServiceTest.php
+++ b/tests/Unit/Services/RealmAssignmentServiceTest.php
@@ -823,6 +823,50 @@ class RealmAssignmentServiceTest extends AbstractTestCase
         }
     }
 
+    public function testNonDiscordRealmAssignmentDoesNotSplitPacks(): void
+    {
+        $packedNonDiscordPlayer = new Player([
+            'id' => 'packed-non-discord',
+            'rating' => 1500,
+            'packId' => 'pack-1',
+            'hasDiscord' => false,
+        ]);
+        $packedDiscordPlayer = new Player([
+            'id' => 'packed-discord',
+            'rating' => 1500,
+            'packId' => 'pack-1',
+            'hasDiscord' => true,
+        ]);
+        $soloNonDiscordPlayer = new Player([
+            'id' => 'solo-non-discord',
+            'rating' => 1500,
+            'packId' => null,
+            'hasDiscord' => false,
+        ]);
+
+        $this->service->players = collect()
+            ->put($packedNonDiscordPlayer->id, $packedNonDiscordPlayer)
+            ->put($packedDiscordPlayer->id, $packedDiscordPlayer)
+            ->put($soloNonDiscordPlayer->id, $soloNonDiscordPlayer);
+
+        $this->service->createNonDiscordRealms();
+
+        $this->assertTrue($this->service->players->has($packedNonDiscordPlayer->id));
+        $this->assertTrue($this->service->players->has($packedDiscordPlayer->id));
+        $this->assertFalse($this->service->players->has($soloNonDiscordPlayer->id));
+        $this->assertCount(1, $this->service->nonDiscordRealms);
+        $this->assertTrue(
+            $this->service->nonDiscordRealms->first()->players->has($soloNonDiscordPlayer->id)
+        );
+        $this->assertFalse(
+            $this->service->nonDiscordRealms->first()->players->has($packedNonDiscordPlayer->id)
+        );
+
+        $this->service->loadPacks();
+
+        $this->assertCount(2, $this->service->packs->get('pack-1')->members);
+    }
+
     /**
      * Test calculateRealmCount grows the realm count when total packed players
      * would exceed the packed-player headroom of the minimum realm count.

--- a/tests/Unit/Services/RealmAssignmentServiceTest.php
+++ b/tests/Unit/Services/RealmAssignmentServiceTest.php
@@ -5,6 +5,7 @@ namespace OpenDominion\Tests\Unit\Services;
 use Illuminate\Support\Collection;
 use OpenDominion\Models\Pack;
 use OpenDominion\Models\Race;
+use OpenDominion\Models\Round;
 use OpenDominion\Services\PlaceholderPack;
 use OpenDominion\Services\PlaceholderRealm;
 use OpenDominion\Services\Player;
@@ -823,7 +824,7 @@ class RealmAssignmentServiceTest extends AbstractTestCase
         }
     }
 
-    public function testNonDiscordRealmAssignmentDoesNotSplitPacks(): void
+    public function testAssignmentOrchestrationKeepsNonDiscordPackMemberWithPack(): void
     {
         $packedNonDiscordPlayer = new Player([
             'id' => 'packed-non-discord',
@@ -844,27 +845,32 @@ class RealmAssignmentServiceTest extends AbstractTestCase
             'hasDiscord' => false,
         ]);
 
-        $this->service->players = collect()
+        $service = $this->getMockBuilder(RealmAssignmentService::class)
+            ->onlyMethods(['loadPlayers'])
+            ->getMock();
+        $service->expects($this->once())
+            ->method('loadPlayers');
+        $service->players = collect()
             ->put($packedNonDiscordPlayer->id, $packedNonDiscordPlayer)
             ->put($packedDiscordPlayer->id, $packedDiscordPlayer)
             ->put($soloNonDiscordPlayer->id, $soloNonDiscordPlayer);
 
-        $this->service->createNonDiscordRealms();
+        $service->assignRealms(new Round(), true);
 
-        $this->assertTrue($this->service->players->has($packedNonDiscordPlayer->id));
-        $this->assertTrue($this->service->players->has($packedDiscordPlayer->id));
-        $this->assertFalse($this->service->players->has($soloNonDiscordPlayer->id));
-        $this->assertCount(1, $this->service->nonDiscordRealms);
-        $this->assertTrue(
-            $this->service->nonDiscordRealms->first()->players->has($soloNonDiscordPlayer->id)
-        );
-        $this->assertFalse(
-            $this->service->nonDiscordRealms->first()->players->has($packedNonDiscordPlayer->id)
-        );
+        $packRealm = $service->realms->first(function (PlaceholderRealm $realm) use ($packedNonDiscordPlayer) {
+            return $realm->players->has($packedNonDiscordPlayer->id);
+        });
+        $nonDiscordRealm = $service->realms->first(function (PlaceholderRealm $realm) use ($soloNonDiscordPlayer) {
+            return $realm->players->has($soloNonDiscordPlayer->id);
+        });
 
-        $this->service->loadPacks();
-
-        $this->assertCount(2, $this->service->packs->get('pack-1')->members);
+        $this->assertNotNull($packRealm);
+        $this->assertTrue($packRealm->discordEnabled);
+        $this->assertTrue($packRealm->players->has($packedDiscordPlayer->id));
+        $this->assertCount(2, $packRealm->players);
+        $this->assertNotNull($nonDiscordRealm);
+        $this->assertFalse($nonDiscordRealm->discordEnabled);
+        $this->assertFalse($nonDiscordRealm->players->has($packedNonDiscordPlayer->id));
     }
 
     /**


### PR DESCRIPTION
## Summary

This draft originally assumed the non-Discord realm pass could pull an opted-out player away from their pack. Review of the production orchestration showed that `assignRealms()` calls `loadPacks()` first, which moves all packed players out of the solo collection before the non-Discord pass runs.

The revised change removes the redundant production filter and adds a production-order invariant test instead. The test runs `assignRealms()` while stubbing only database loading, then verifies that an opted-out packed player remains in a Discord-enabled realm with their packmate while an opted-out solo enters a non-Discord realm. The technical reference now states the existing behavior explicitly.

## User impact

There is no production behavior change. The test protects the existing guarantee that joining a pack keeps its members together regardless of an earlier Discord preference.

## Verification

- The replacement production-order test passes with the branch and with the parent selection logic, confirming this path was not buggy.
- Passed the pure realm-assignment/pack test subset: 6 tests, 165 assertions.
- Passed PHP syntax checks and `git diff --check`.
