### PR TITLE
Normalize unrated player ratings in realm assignment

### DIFF
--- a/docs/claude/MODELS.md
+++ b/docs/claude/MODELS.md
@@ -26,7 +26,7 @@ User ──has many──→ Dominion ──belongs to──→ Round
 - **Traits**: Authenticatable, Authorizable, HasRoles (Spatie), Notifiable
 - **Casts**: settings (array), affinities (array)
 - **Relations**: dominions, activities, identities, origins, discordUser, feedback, endorsements, achievements
-- **Key methods**: `isStaff()`, `isOnline()` (5min), `isInactive()` (72h), `getSetting()`, `getAffinity()`
+- **Key methods**: `isStaff()`, `isOnline()` (5min), `isInactive()` (72h), `getSetting()`, `getAffinity()`, `getEffectiveRating()` (uses 1000 for unrated users)
 
 ### Round (`rounds`)
 - **Relations**: dominions (through Realm), realms, packs, raids, tournaments, wonders, gameEvents, wars (through Realm), league

--- a/docs/claude/SERVICES.md
+++ b/docs/claude/SERVICES.md
@@ -125,6 +125,7 @@ Daily ranking snapshots by category (land, networth, conquered, explored, etc.).
 Sophisticated pre-round realm assignment algorithm.
 - Constants: `MAX_PACKS_PER_REALM` = 3, `MAX_PACKED_PLAYERS_PER_REALM` = 8, realms 8-14
 - Uses nested classes: Player, PlaceholderPack, PlaceholderRealm
+- Resolves the database's unrated-player sentinel to rating 1000 before assignment scoring
 - Scoring: compatibility (favorability + playstyle balance) + rating deviation + size bonus
 - Optimization: 50 iterations of random solo-player swapping
 
@@ -142,6 +143,7 @@ Town Crier event retrieval.
 
 ### UserRatingService
 Player skill ratings from round performance.
+- Default rating: 1000 (shared with `User::DEFAULT_RATING`)
 - Formula: 2000 * exp(-0.005 * (rank - 1)) + bonuses (land, ops, bounties, activity)
 - Playstyle affinities: attacker, converter, explorer, ops
 - Averages best 3 finishes + feedback score

--- a/src/Factories/DominionFactory.php
+++ b/src/Factories/DominionFactory.php
@@ -148,10 +148,15 @@ class DominionFactory
         }
 
         if (!$realm->round->hasStarted()) {
+            $realmPlayers = $realm->dominions()
+                ->human()
+                ->with('user')
+                ->get();
+
             $realm->rating = (int) round(
-                Dominion::where('dominions.realm_id', $realm->id)
-                    ->join('users', 'users.id', '=', 'dominions.user_id')
-                    ->avg('users.rating') ?? 0
+                $realmPlayers->avg(
+                    fn (Dominion $realmDominion): float => $realmDominion->user->getEffectiveRating()
+                ) ?? 0
             );
             $realm->save();
         }

--- a/src/Models/User.php
+++ b/src/Models/User.php
@@ -56,18 +56,6 @@ class User extends AbstractModel implements AuthenticatableContract, Authorizabl
 
     public const DEFAULT_RATING = 1000.0;
 
-    /**
-     * Neutral playstyle profile used until calculated affinities are available.
-     *
-     * @var array<string, float>
-     */
-    public const DEFAULT_AFFINITIES = [
-        'attacker' => 50.0,
-        'converter' => 30.0,
-        'explorer' => 50.0,
-        'ops' => 30.0,
-    ];
-
     protected $casts = [
         'settings' => 'array',
         'affinities' => 'array',
@@ -187,29 +175,13 @@ class User extends AbstractModel implements AuthenticatableContract, Authorizabl
         return $rating;
     }
 
-    /**
-     * Return calculated affinities, or the neutral profile for missing and
-     * legacy zero-only values.
-     *
-     * @return array<string, float>
-     */
-    public function getEffectiveAffinities(): array
+    public function getAffinity(string $key)
     {
-        $affinities = array_map(
-            static fn ($affinity): float => (float) $affinity,
-            $this->affinities ?? []
-        );
-
-        if (array_sum($affinities) <= 0) {
-            return self::DEFAULT_AFFINITIES;
+        if (!Arr::has($this->affinities, $key)) {
+            return 50;
         }
 
-        return array_replace(self::DEFAULT_AFFINITIES, $affinities);
-    }
-
-    public function getAffinity(string $key): float
-    {
-        return $this->getEffectiveAffinities()[$key] ?? 0.0;
+        return Arr::get($this->affinities, $key);
     }
 
     /**

--- a/src/Models/User.php
+++ b/src/Models/User.php
@@ -54,6 +54,20 @@ class User extends AbstractModel implements AuthenticatableContract, Authorizabl
 {
     use Authenticatable, Authorizable, CanResetPassword, HasFactory, HasRoles, Notifiable;
 
+    public const DEFAULT_RATING = 1000.0;
+
+    /**
+     * Neutral playstyle profile used until calculated affinities are available.
+     *
+     * @var array<string, float>
+     */
+    public const DEFAULT_AFFINITIES = [
+        'attacker' => 50.0,
+        'converter' => 30.0,
+        'explorer' => 50.0,
+        'ops' => 30.0,
+    ];
+
     protected $casts = [
         'settings' => 'array',
         'affinities' => 'array',
@@ -162,13 +176,40 @@ class User extends AbstractModel implements AuthenticatableContract, Authorizabl
         return Arr::get($this->settings, $key);
     }
 
-    public function getAffinity(string $key)
+    public function getEffectiveRating(): float
     {
-        if (!Arr::has($this->affinities, $key)) {
-            return 50;
+        $rating = (float) ($this->rating ?? 0);
+
+        if ($rating <= 0) {
+            return self::DEFAULT_RATING;
         }
 
-        return Arr::get($this->affinities, $key);
+        return $rating;
+    }
+
+    /**
+     * Return calculated affinities, or the neutral profile for missing and
+     * legacy zero-only values.
+     *
+     * @return array<string, float>
+     */
+    public function getEffectiveAffinities(): array
+    {
+        $affinities = array_map(
+            static fn ($affinity): float => (float) $affinity,
+            $this->affinities ?? []
+        );
+
+        if (array_sum($affinities) <= 0) {
+            return self::DEFAULT_AFFINITIES;
+        }
+
+        return array_replace(self::DEFAULT_AFFINITIES, $affinities);
+    }
+
+    public function getAffinity(string $key): float
+    {
+        return $this->getEffectiveAffinities()[$key] ?? 0.0;
     }
 
     /**

--- a/src/Services/RealmAssignmentService.php
+++ b/src/Services/RealmAssignmentService.php
@@ -48,6 +48,25 @@ class Player
     }
 
     /**
+     * Create an assignment player using the user's effective rating profile.
+     *
+     * Database zero/null values remain storage sentinels and are resolved here
+     * before they can affect assignment scoring.
+     */
+    public static function fromUser(User $user, array $attributes = []): self
+    {
+        $affinities = $user->getEffectiveAffinities();
+
+        return new self(array_merge($attributes, [
+            'rating' => $user->getEffectiveRating(),
+            'attackerAffinity' => $affinities['attacker'],
+            'converterAffinity' => $affinities['converter'],
+            'explorerAffinity' => $affinities['explorer'],
+            'opsAffinity' => $affinities['ops'],
+        ]));
+    }
+
+    /**
      * Get favorability score with another player
      *
      * Returns the favorability rating this player has given to another player.
@@ -148,10 +167,10 @@ class PlaceholderRealm
      * @var array Ideal average playstyle affinities per player for balanced realms
      */
     public const IDEAL_COMPOSITION = [
-        'attackerAffinity' => 50,
-        'converterAffinity' => 30,
-        'explorerAffinity' => 50,
-        'opsAffinity' => 30,
+        'attackerAffinity' => User::DEFAULT_AFFINITIES['attacker'],
+        'converterAffinity' => User::DEFAULT_AFFINITIES['converter'],
+        'explorerAffinity' => User::DEFAULT_AFFINITIES['explorer'],
+        'opsAffinity' => User::DEFAULT_AFFINITIES['ops'],
     ];
 
     public string $id;
@@ -563,9 +582,8 @@ class RealmAssignmentService
      * Load all registered players for the round
      *
      * Fetches all registered dominions from the database and converts them
-     * to Player objects with favorability matrices, playstyle ratings, and
-     * other assignment-relevant data. Placeholder playstyle data is used
-     * until proper calculation is implemented.
+     * to Player objects with favorability matrices, effective ratings,
+     * playstyle affinities, and other assignment-relevant data.
      *
      * @param Round $round The round to load players for
      */
@@ -595,16 +613,11 @@ class RealmAssignmentService
             $hasDiscord = !($discordSetting !== null && $discordSetting === false);
 
             // Create player
-            $player = new Player([
+            $player = Player::fromUser($dominion->user, [
                 'id' => $dominion->id,
                 'packId' => $dominion->pack_id,
-                'rating' => $dominion->user->rating ?? 0,
                 'favorability' => $favorabilityMatrix,
                 'hasDiscord' => $hasDiscord,
-                'attackerAffinity' => $dominion->user->getAffinity('attacker'),
-                'converterAffinity' => $dominion->user->getAffinity('converter'),
-                'explorerAffinity' => $dominion->user->getAffinity('explorer'),
-                'opsAffinity' => $dominion->user->getAffinity('ops'),
             ]);
             $this->players->put($dominion->id, $player);
         }
@@ -1456,7 +1469,7 @@ class RealmAssignmentService
             return $round->realms()->where('number', 0)->first();
         }
 
-        if (!$useDiscord && !($user->rating > 1800)) {
+        if (!$useDiscord && !($user->getEffectiveRating() > 1800)) {
             // Filter down to non-Discord realms (those with usediscord = false in settings)
             $nonDiscordRealms = $round->realms->filter(function ($realm) {
                 return $realm->getSetting('usediscord') === false;
@@ -1569,15 +1582,10 @@ class RealmAssignmentService
             return [$targetId => $positive - $negative];
         })->toArray();
 
-        return new Player([
+        return Player::fromUser($user, [
             'id' => $user->id,
             'packId' => null, // Individual registration
-            'rating' => $user->rating ?? 0,
             'favorability' => $favorabilityMatrix,
-            'attackerAffinity' => $user->getAffinity('attacker'),
-            'converterAffinity' => $user->getAffinity('converter'),
-            'explorerAffinity' => $user->getAffinity('explorer'),
-            'opsAffinity' => $user->getAffinity('ops'),
         ]);
     }
 
@@ -1620,15 +1628,10 @@ class RealmAssignmentService
     public function createPlaceholderRealm(Realm $realm): PlaceholderRealm
     {
         $players = $realm->dominions()->human()->get()->map(function ($dominion) {
-            return new Player([
+            return Player::fromUser($dominion->user, [
                 'id' => $dominion->user_id,
                 'packId' => $dominion->pack_id,
-                'rating' => $dominion->user->rating ?? 0,
                 'favorability' => [], // Not needed for existing players in this context
-                'attackerAffinity' => $dominion->user->getAffinity('attacker'),
-                'converterAffinity' => $dominion->user->getAffinity('converter'),
-                'explorerAffinity' => $dominion->user->getAffinity('explorer'),
-                'opsAffinity' => $dominion->user->getAffinity('ops'),
             ]);
         });
 

--- a/src/Services/RealmAssignmentService.php
+++ b/src/Services/RealmAssignmentService.php
@@ -48,21 +48,19 @@ class Player
     }
 
     /**
-     * Create an assignment player using the user's effective rating profile.
+     * Create an assignment player using the user's effective rating.
      *
-     * Database zero/null values remain storage sentinels and are resolved here
-     * before they can affect assignment scoring.
+     * The database zero value remains a storage sentinel and is resolved here
+     * before it can affect assignment scoring.
      */
     public static function fromUser(User $user, array $attributes = []): self
     {
-        $affinities = $user->getEffectiveAffinities();
-
         return new self(array_merge($attributes, [
             'rating' => $user->getEffectiveRating(),
-            'attackerAffinity' => $affinities['attacker'],
-            'converterAffinity' => $affinities['converter'],
-            'explorerAffinity' => $affinities['explorer'],
-            'opsAffinity' => $affinities['ops'],
+            'attackerAffinity' => $user->getAffinity('attacker'),
+            'converterAffinity' => $user->getAffinity('converter'),
+            'explorerAffinity' => $user->getAffinity('explorer'),
+            'opsAffinity' => $user->getAffinity('ops'),
         ]));
     }
 
@@ -167,10 +165,10 @@ class PlaceholderRealm
      * @var array Ideal average playstyle affinities per player for balanced realms
      */
     public const IDEAL_COMPOSITION = [
-        'attackerAffinity' => User::DEFAULT_AFFINITIES['attacker'],
-        'converterAffinity' => User::DEFAULT_AFFINITIES['converter'],
-        'explorerAffinity' => User::DEFAULT_AFFINITIES['explorer'],
-        'opsAffinity' => User::DEFAULT_AFFINITIES['ops'],
+        'attackerAffinity' => 50,
+        'converterAffinity' => 30,
+        'explorerAffinity' => 50,
+        'opsAffinity' => 30,
     ];
 
     public string $id;

--- a/src/Services/UserRatingService.php
+++ b/src/Services/UserRatingService.php
@@ -18,7 +18,7 @@ use OpenDominion\Models\User;
  */
 class UserRatingService
 {
-    const DEFAULT_RATING = 1000.0;
+    public const DEFAULT_RATING = User::DEFAULT_RATING;
 
     protected $landCalculator;
 
@@ -37,7 +37,7 @@ class UserRatingService
     {
         $ratings = $this->calculateUserRatings($user);
 
-        $oldRating = $user->rating ?? self::DEFAULT_RATING;
+        $oldRating = $user->getEffectiveRating();
         $newRating = $ratings['rating'];
         $rankingChanged = ($newRating !== $oldRating);
 
@@ -251,12 +251,7 @@ class UserRatingService
         $totalScores = count($dominionScores);
 
         if ($totalScores === 0) {
-            return [
-                'attacker' => 0,
-                'explorer' => 0,
-                'converter' => 0,
-                'ops' => 0,
-            ];
+            return User::DEFAULT_AFFINITIES;
         }
 
         $attackerCount = 0;

--- a/src/Services/UserRatingService.php
+++ b/src/Services/UserRatingService.php
@@ -37,7 +37,7 @@ class UserRatingService
     {
         $ratings = $this->calculateUserRatings($user);
 
-        $oldRating = $user->getEffectiveRating();
+        $oldRating = $user->rating ?? self::DEFAULT_RATING;
         $newRating = $ratings['rating'];
         $rankingChanged = ($newRating !== $oldRating);
 
@@ -251,7 +251,12 @@ class UserRatingService
         $totalScores = count($dominionScores);
 
         if ($totalScores === 0) {
-            return User::DEFAULT_AFFINITIES;
+            return [
+                'attacker' => 0,
+                'explorer' => 0,
+                'converter' => 0,
+                'ops' => 0,
+            ];
         }
 
         $attackerCount = 0;

--- a/tests/Unit/Factories/DominionFactoryTest.php
+++ b/tests/Unit/Factories/DominionFactoryTest.php
@@ -68,6 +68,35 @@ class DominionFactoryTest extends AbstractBrowserKitTestCase
         $this->assertEquals($dominion->id, $this->round->dominions()->first()->id);
     }
 
+    public function testCreateUsesEffectiveRatingsForPreStartRealmAverage(): void
+    {
+        $this->round->start_date = now()->addDay();
+        $this->round->save();
+        $this->realm->unsetRelation('round');
+
+        $this->user->rating = 0;
+        $this->user->save();
+
+        $this->dominionFactory->create(
+            $this->user,
+            $this->realm,
+            $this->race,
+            'Unrated Ruler',
+            'Unrated Dominion'
+        );
+
+        $ratedUser = $this->createUser(null, ['rating' => 1800]);
+        $this->dominionFactory->create(
+            $ratedUser,
+            $this->realm,
+            $this->race,
+            'Rated Ruler',
+            'Rated Dominion'
+        );
+
+        $this->assertSame(1400, $this->realm->fresh()->rating);
+    }
+
     public function testStartingResources()
     {
         $dominion = $this->dominionFactory->create(

--- a/tests/Unit/Models/UserTest.php
+++ b/tests/Unit/Models/UserTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace OpenDominion\Tests\Unit\Models;
+
+use OpenDominion\Models\User;
+use PHPUnit\Framework\TestCase;
+
+class UserTest extends TestCase
+{
+    public function testUnratedUserResolvesToNeutralRatingProfile(): void
+    {
+        $user = new User();
+        $user->rating = 0;
+        $user->affinities = null;
+
+        $this->assertSame(User::DEFAULT_RATING, $user->getEffectiveRating());
+        $this->assertSame(User::DEFAULT_AFFINITIES, $user->getEffectiveAffinities());
+        $this->assertSame(User::DEFAULT_AFFINITIES['attacker'], $user->getAffinity('attacker'));
+        $this->assertSame(User::DEFAULT_AFFINITIES['converter'], $user->getAffinity('converter'));
+        $this->assertSame(User::DEFAULT_AFFINITIES['explorer'], $user->getAffinity('explorer'));
+        $this->assertSame(User::DEFAULT_AFFINITIES['ops'], $user->getAffinity('ops'));
+    }
+
+    public function testLegacyZeroAffinitiesResolveToNeutralProfile(): void
+    {
+        $user = new User();
+        $user->affinities = [
+            'attacker' => 0,
+            'converter' => 0,
+            'explorer' => 0,
+            'ops' => 0,
+        ];
+
+        $this->assertSame(User::DEFAULT_AFFINITIES, $user->getEffectiveAffinities());
+    }
+
+    public function testCalculatedRatingProfileOverridesNeutralDefaults(): void
+    {
+        $user = new User();
+        $user->rating = 1725;
+        $user->affinities = [
+            'attacker' => 80,
+            'converter' => 40,
+            'explorer' => 20,
+            'ops' => 10,
+        ];
+
+        $this->assertSame(1725.0, $user->getEffectiveRating());
+        $this->assertSame([
+            'attacker' => 80.0,
+            'converter' => 40.0,
+            'explorer' => 20.0,
+            'ops' => 10.0,
+        ], $user->getEffectiveAffinities());
+        $this->assertSame(80.0, $user->getAffinity('attacker'));
+        $this->assertSame(40.0, $user->getAffinity('converter'));
+        $this->assertSame(20.0, $user->getAffinity('explorer'));
+        $this->assertSame(10.0, $user->getAffinity('ops'));
+    }
+}

--- a/tests/Unit/Models/UserTest.php
+++ b/tests/Unit/Models/UserTest.php
@@ -7,54 +7,19 @@ use PHPUnit\Framework\TestCase;
 
 class UserTest extends TestCase
 {
-    public function testUnratedUserResolvesToNeutralRatingProfile(): void
+    public function testUnratedUserResolvesToDefaultRating(): void
     {
         $user = new User();
         $user->rating = 0;
-        $user->affinities = null;
 
         $this->assertSame(User::DEFAULT_RATING, $user->getEffectiveRating());
-        $this->assertSame(User::DEFAULT_AFFINITIES, $user->getEffectiveAffinities());
-        $this->assertSame(User::DEFAULT_AFFINITIES['attacker'], $user->getAffinity('attacker'));
-        $this->assertSame(User::DEFAULT_AFFINITIES['converter'], $user->getAffinity('converter'));
-        $this->assertSame(User::DEFAULT_AFFINITIES['explorer'], $user->getAffinity('explorer'));
-        $this->assertSame(User::DEFAULT_AFFINITIES['ops'], $user->getAffinity('ops'));
     }
 
-    public function testLegacyZeroAffinitiesResolveToNeutralProfile(): void
-    {
-        $user = new User();
-        $user->affinities = [
-            'attacker' => 0,
-            'converter' => 0,
-            'explorer' => 0,
-            'ops' => 0,
-        ];
-
-        $this->assertSame(User::DEFAULT_AFFINITIES, $user->getEffectiveAffinities());
-    }
-
-    public function testCalculatedRatingProfileOverridesNeutralDefaults(): void
+    public function testRatedUserKeepsStoredRating(): void
     {
         $user = new User();
         $user->rating = 1725;
-        $user->affinities = [
-            'attacker' => 80,
-            'converter' => 40,
-            'explorer' => 20,
-            'ops' => 10,
-        ];
 
         $this->assertSame(1725.0, $user->getEffectiveRating());
-        $this->assertSame([
-            'attacker' => 80.0,
-            'converter' => 40.0,
-            'explorer' => 20.0,
-            'ops' => 10.0,
-        ], $user->getEffectiveAffinities());
-        $this->assertSame(80.0, $user->getAffinity('attacker'));
-        $this->assertSame(40.0, $user->getAffinity('converter'));
-        $this->assertSame(20.0, $user->getAffinity('explorer'));
-        $this->assertSame(10.0, $user->getAffinity('ops'));
     }
 }

--- a/tests/Unit/Services/RealmAssignmentServiceTest.php
+++ b/tests/Unit/Services/RealmAssignmentServiceTest.php
@@ -26,25 +26,24 @@ class RealmAssignmentServiceTest extends AbstractTestCase
         $this->service = new RealmAssignmentService();
     }
 
-    public function testPlayerFactoryResolvesUnratedUserDefaults(): void
+    public function testPlayerFactoryUsesEffectiveRatingWithoutChangingAffinities(): void
     {
         $user = new User();
         $user->rating = 0;
-        $user->affinities = null;
+        $user->affinities = [
+            'attacker' => 80,
+            'converter' => 40,
+            'explorer' => 20,
+            'ops' => 10,
+        ];
 
         $player = Player::fromUser($user, ['id' => 'new-player']);
 
         $this->assertSame(User::DEFAULT_RATING, $player->rating);
-        $this->assertSame(User::DEFAULT_AFFINITIES['attacker'], $player->attackerAffinity);
-        $this->assertSame(User::DEFAULT_AFFINITIES['converter'], $player->converterAffinity);
-        $this->assertSame(User::DEFAULT_AFFINITIES['explorer'], $player->explorerAffinity);
-        $this->assertSame(User::DEFAULT_AFFINITIES['ops'], $player->opsAffinity);
-        $this->assertSame([
-            'attackerAffinity' => $player->attackerAffinity,
-            'converterAffinity' => $player->converterAffinity,
-            'explorerAffinity' => $player->explorerAffinity,
-            'opsAffinity' => $player->opsAffinity,
-        ], PlaceholderRealm::IDEAL_COMPOSITION);
+        $this->assertSame(80.0, $player->attackerAffinity);
+        $this->assertSame(40.0, $player->converterAffinity);
+        $this->assertSame(20.0, $player->explorerAffinity);
+        $this->assertSame(10.0, $player->opsAffinity);
     }
 
     /**

--- a/tests/Unit/Services/RealmAssignmentServiceTest.php
+++ b/tests/Unit/Services/RealmAssignmentServiceTest.php
@@ -5,6 +5,7 @@ namespace OpenDominion\Tests\Unit\Services;
 use Illuminate\Support\Collection;
 use OpenDominion\Models\Pack;
 use OpenDominion\Models\Race;
+use OpenDominion\Models\User;
 use OpenDominion\Services\PlaceholderPack;
 use OpenDominion\Services\PlaceholderRealm;
 use OpenDominion\Services\Player;
@@ -23,6 +24,27 @@ class RealmAssignmentServiceTest extends AbstractTestCase
     {
         parent::setUp();
         $this->service = new RealmAssignmentService();
+    }
+
+    public function testPlayerFactoryResolvesUnratedUserDefaults(): void
+    {
+        $user = new User();
+        $user->rating = 0;
+        $user->affinities = null;
+
+        $player = Player::fromUser($user, ['id' => 'new-player']);
+
+        $this->assertSame(User::DEFAULT_RATING, $player->rating);
+        $this->assertSame(User::DEFAULT_AFFINITIES['attacker'], $player->attackerAffinity);
+        $this->assertSame(User::DEFAULT_AFFINITIES['converter'], $player->converterAffinity);
+        $this->assertSame(User::DEFAULT_AFFINITIES['explorer'], $player->explorerAffinity);
+        $this->assertSame(User::DEFAULT_AFFINITIES['ops'], $player->opsAffinity);
+        $this->assertSame([
+            'attackerAffinity' => $player->attackerAffinity,
+            'converterAffinity' => $player->converterAffinity,
+            'explorerAffinity' => $player->explorerAffinity,
+            'opsAffinity' => $player->opsAffinity,
+        ], PlaceholderRealm::IDEAL_COMPOSITION);
     }
 
     /**

--- a/tests/Unit/Services/UserRatingServiceTest.php
+++ b/tests/Unit/Services/UserRatingServiceTest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace OpenDominion\Tests\Unit\Services;
+
+use OpenDominion\Calculators\Dominion\LandCalculator;
+use OpenDominion\Models\User;
+use OpenDominion\Services\UserRatingService;
+use PHPUnit\Framework\TestCase;
+
+class UserRatingServiceTest extends TestCase
+{
+    private UserRatingService $service;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->service = new UserRatingService($this->createStub(LandCalculator::class));
+    }
+
+    public function testNoHistoryUsesNeutralRatingProfile(): void
+    {
+        $this->assertSame(User::DEFAULT_RATING, $this->service->averageBestFinishes([]));
+        $this->assertSame(User::DEFAULT_AFFINITIES, $this->service->calculateAffinities([]));
+    }
+}

--- a/tests/Unit/Services/UserRatingServiceTest.php
+++ b/tests/Unit/Services/UserRatingServiceTest.php
@@ -18,9 +18,8 @@ class UserRatingServiceTest extends TestCase
         $this->service = new UserRatingService($this->createStub(LandCalculator::class));
     }
 
-    public function testNoHistoryUsesNeutralRatingProfile(): void
+    public function testNoHistoryUsesDefaultRating(): void
     {
         $this->assertSame(User::DEFAULT_RATING, $this->service->averageBestFinishes([]));
-        $this->assertSame(User::DEFAULT_AFFINITIES, $this->service->calculateAffinities([]));
     }
 }


### PR DESCRIPTION
## Description

- Keep the database default (`rating = 0`) as an unrated storage sentinel.
- Define one canonical effective rating of `1000` for unrated users.
- Resolve that rating at the assignment boundary for bulk assignment, late registration, existing-realm scoring, and the non-Discord rating threshold.
- Calculate pre-start persisted realm ratings from effective player ratings so late assignment uses the same strength values.
- Preserve the existing affinity storage, fallback, and playstyle-scoring behavior unchanged.

## Motivation and Context

The user rating column is non-nullable and defaults to zero, so expressions such as `$user->rating ?? 0` never substituted `UserRatingService::DEFAULT_RATING`. Unrated players consequently entered assignment strength calculations at zero instead of the intended rating of 1000.

This revision deliberately does not assign an ideal playstyle profile to users with unknown affinities. That behavior was removed in response to review feedback because an ideal profile would influence non-ideal realm composition rather than remain neutral.

## How Has This Been Tested?

- Pure model, rating-service, and realm-assignment coverage: 9 tests, 165 assertions passing.
- Known affinities are preserved unchanged when an unrated user becomes an assignment player.
- The database-backed pre-start realm-average regression remains included. Its local run is blocked by the unavailable `mariadb` host; GitHub Actions provides the database environment.
- PHP syntax checks and `git diff --check` pass.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] Relevant technical documentation is updated.
- [x] Tests cover the changed behavior.
