### PR TITLE
Improve Ops Center navigation on mobile and archives

### DIFF
--- a/app/resources/sass/app.scss
+++ b/app/resources/sass/app.scss
@@ -120,6 +120,12 @@ a {
   scrollbar-width: thin;
 }
 
+@media (max-width: 767.98px) {
+  .op-center-navigation-scroller {
+    padding-bottom: 0.625rem;
+  }
+}
+
 .op-center-report-anchor {
   scroll-margin-top: 4.75rem;
 }

--- a/app/resources/sass/app.scss
+++ b/app/resources/sass/app.scss
@@ -122,7 +122,7 @@ a {
 
 @media (max-width: 767.98px) {
   .op-center-navigation-scroller {
-    padding-bottom: 0.625rem;
+    padding-bottom: 0.5rem;
   }
 }
 

--- a/app/resources/views/pages/dominion/op-center/archive.blade.php
+++ b/app/resources/views/pages/dominion/op-center/archive.blade.php
@@ -3,6 +3,11 @@
 @section('page-header', 'Op Center')
 
 @section('content')
+    @include('partials.dominion.op-center.navigation', [
+        'archiveDominion' => $dominion,
+        'activeInfoOpType' => $activeInfoOpType,
+    ])
+
     <div class="row">
         <div class="col-sm-12 col-md-9">
             @component('partials.dominion.op-center.box')

--- a/app/resources/views/partials/dominion/op-center/navigation.blade.php
+++ b/app/resources/views/partials/dominion/op-center/navigation.blade.php
@@ -1,3 +1,18 @@
+@php
+    $informationOperations = [
+        'clear_sight' => ['anchor' => 'op-clear-sight', 'label' => 'Clear Sight'],
+        'revelation' => ['anchor' => 'op-revelation', 'label' => 'Revelation'],
+        'castle_spy' => ['anchor' => 'op-castle-spy', 'label' => 'Castle Spy'],
+        'barracks_spy' => ['anchor' => 'op-barracks-spy', 'label' => 'Barracks Spy'],
+        'survey_dominion' => ['anchor' => 'op-survey-dominion', 'label' => 'Survey Dominion'],
+        'land_spy' => ['anchor' => 'op-land-spy', 'label' => 'Land Spy'],
+        'vision' => ['anchor' => 'op-vision', 'label' => 'Vision'],
+        'disclosure' => ['anchor' => 'op-disclosure', 'label' => 'Disclosure'],
+    ];
+    $isArchiveNavigation = isset($archiveDominion);
+    $activeInfoOpType = $activeInfoOpType ?? null;
+@endphp
+
 <nav class="op-center-navigation card shadow-sm mb-3" aria-label="Jump to an information operation">
     <div class="card-body d-flex align-items-center gap-2 p-2">
         <span class="text-body-secondary text-nowrap" aria-hidden="true">
@@ -7,14 +22,24 @@
 
         <div class="op-center-navigation-scroller">
             <div class="d-flex gap-2">
-                <a class="btn btn-sm btn-outline-primary" href="#op-clear-sight">Clear Sight</a>
-                <a class="btn btn-sm btn-outline-primary" href="#op-revelation">Revelation</a>
-                <a class="btn btn-sm btn-outline-primary" href="#op-castle-spy">Castle Spy</a>
-                <a class="btn btn-sm btn-outline-primary" href="#op-barracks-spy">Barracks Spy</a>
-                <a class="btn btn-sm btn-outline-primary" href="#op-survey-dominion">Survey Dominion</a>
-                <a class="btn btn-sm btn-outline-primary" href="#op-land-spy">Land Spy</a>
-                <a class="btn btn-sm btn-outline-primary" href="#op-vision">Vision</a>
-                <a class="btn btn-sm btn-outline-primary" href="#op-disclosure">Disclosure</a>
+                @foreach ($informationOperations as $type => $operation)
+                    @php
+                        $isActiveArchive = $isArchiveNavigation && $activeInfoOpType === $type;
+                        $href = $isArchiveNavigation
+                            ? route('dominion.op-center.archive', [$archiveDominion, $type])
+                            : '#' . $operation['anchor'];
+                    @endphp
+                    <a
+                        @class([
+                            'btn',
+                            'btn-sm',
+                            'btn-outline-primary',
+                            'active' => $isActiveArchive,
+                        ])
+                        href="{{ $href }}"
+                        @if ($isActiveArchive) aria-current="page" @endif
+                    >{{ $operation['label'] }}</a>
+                @endforeach
             </div>
         </div>
     </div>

--- a/src/Http/Controllers/Dominion/OpCenterController.php
+++ b/src/Http/Controllers/Dominion/OpCenterController.php
@@ -200,7 +200,8 @@ class OpCenterController extends AbstractDominionController
             'unitHelper' => app(UnitHelper::class),
             'miscHelper' => app(MiscHelper::class),
             'dominion' => $dominion,
-            'infoOpArchive' => $infoOpArchive
+            'infoOpArchive' => $infoOpArchive,
+            'activeInfoOpType' => $type,
         ]);
     }
 

--- a/tests/Feature/Http/Dominion/OpCenterNavigationTest.php
+++ b/tests/Feature/Http/Dominion/OpCenterNavigationTest.php
@@ -6,6 +6,17 @@ use OpenDominion\Tests\AbstractTestCase;
 
 class OpCenterNavigationTest extends AbstractTestCase
 {
+    private const INFORMATION_OPERATIONS = [
+        'clear_sight' => ['anchor' => 'op-clear-sight', 'label' => 'Clear Sight'],
+        'revelation' => ['anchor' => 'op-revelation', 'label' => 'Revelation'],
+        'castle_spy' => ['anchor' => 'op-castle-spy', 'label' => 'Castle Spy'],
+        'barracks_spy' => ['anchor' => 'op-barracks-spy', 'label' => 'Barracks Spy'],
+        'survey_dominion' => ['anchor' => 'op-survey-dominion', 'label' => 'Survey Dominion'],
+        'land_spy' => ['anchor' => 'op-land-spy', 'label' => 'Land Spy'],
+        'vision' => ['anchor' => 'op-vision', 'label' => 'Vision'],
+        'disclosure' => ['anchor' => 'op-disclosure', 'label' => 'Disclosure'],
+    ];
+
     public function testNavigationLinksToEveryInformationOperationSection(): void
     {
         $html = view('partials.dominion.op-center.navigation')->render();
@@ -14,23 +25,42 @@ class OpCenterNavigationTest extends AbstractTestCase
         $this->assertIsString($opCenterView);
         $this->assertStringContainsString("@include('partials.dominion.op-center.navigation')", $opCenterView);
 
-        $expectedOperations = [
-            'op-clear-sight' => 'Clear Sight',
-            'op-revelation' => 'Revelation',
-            'op-castle-spy' => 'Castle Spy',
-            'op-barracks-spy' => 'Barracks Spy',
-            'op-survey-dominion' => 'Survey Dominion',
-            'op-land-spy' => 'Land Spy',
-            'op-vision' => 'Vision',
-            'op-disclosure' => 'Disclosure',
-        ];
-
-        foreach ($expectedOperations as $anchor => $label) {
-            $this->assertStringContainsString('href="#' . $anchor . '"', $html);
-            $this->assertStringContainsString('>' . $label . '</a>', $html);
-            $this->assertStringContainsString('id="' . $anchor . '"', $opCenterView);
+        foreach (self::INFORMATION_OPERATIONS as $operation) {
+            $this->assertStringContainsString('href="#' . $operation['anchor'] . '"', $html);
+            $this->assertStringContainsString('>' . $operation['label'] . '</a>', $html);
+            $this->assertStringContainsString('id="' . $operation['anchor'] . '"', $opCenterView);
         }
 
-        $this->assertSame(count($expectedOperations), substr_count($html, 'btn-outline-primary'));
+        $this->assertSame(
+            count(self::INFORMATION_OPERATIONS),
+            substr_count($html, 'btn-outline-primary')
+        );
+    }
+
+    public function testNavigationLinksBetweenInformationOperationArchives(): void
+    {
+        $dominionId = 42;
+        $archiveView = file_get_contents(resource_path('views/pages/dominion/op-center/archive.blade.php'));
+        $html = view('partials.dominion.op-center.navigation', [
+            'archiveDominion' => $dominionId,
+            'activeInfoOpType' => 'clear_sight',
+        ])->render();
+
+        $this->assertIsString($archiveView);
+        $this->assertStringContainsString("@include('partials.dominion.op-center.navigation'", $archiveView);
+
+        foreach (self::INFORMATION_OPERATIONS as $type => $operation) {
+            $this->assertStringContainsString(
+                'href="' . route('dominion.op-center.archive', [$dominionId, $type]) . '"',
+                $html
+            );
+            $this->assertStringContainsString('>' . $operation['label'] . '</a>', $html);
+        }
+
+        $this->assertSame(1, substr_count($html, 'aria-current="page"'));
+        $this->assertSame(
+            count(self::INFORMATION_OPERATIONS),
+            substr_count($html, 'btn-outline-primary')
+        );
     }
 }


### PR DESCRIPTION
## Summary

- Keeps the horizontal scrollbar below the Ops Center buttons on mobile with a 0.5rem gutter while preserving the existing 0.125rem desktop spacing.
- Adds the same sticky navigation bar to operation archive pages.
- Lets players switch directly between all eight operation histories for the same dominion without returning to the overview or scrolling back to the top.
- Marks the currently viewed archive as active and exposes it with aria-current.
- Generates both overview and archive links from one shared operation list.

## Validation

- Focused Ops Center navigation test: 2 passed, 47 assertions
- php artisan view:cache
- npm run build
- Playwright mobile check at 390px, including Clear Sight history to Castle Spy history navigation
- Confirmed 8px mobile scrollbar clearance and unchanged 2px desktop clearance