### PR TITLE
Improvements to realm assignment

### DIFF
--- a/src/Services/RealmAssignmentService.php
+++ b/src/Services/RealmAssignmentService.php
@@ -99,27 +99,6 @@ class Player
         return $this->favorability[$userId] ?? 0;
     }
 
-    /**
-     * Get player's primary playstyle based on highest affinity
-     *
-     * Compares all playstyle affinities (attacker, converter, explorer, ops) and
-     * returns the playstyle with the highest value. Used for playstyle distribution
-     * analysis and realm balancing.
-     *
-     * @return string Primary playstyle ('attacker', 'converter', 'explorer', or 'ops')
-     */
-    public function getPrimaryPlaystyle(): string
-    {
-        $affinities = [
-            'attacker' => $this->attackerAffinity,
-            'converter' => $this->converterAffinity,
-            'explorer' => $this->explorerAffinity,
-            'ops' => $this->opsAffinity,
-        ];
-
-        return array_keys($affinities, max($affinities))[0];
-    }
-
     private function attributesContainKnownAffinities(array $attributes): bool
     {
         $hasPositiveAffinity = false;
@@ -197,14 +176,41 @@ class PlaceholderPack
 class PlaceholderRealm
 {
     /**
-     * @var array Ideal average playstyle affinities per player for balanced realms
+     * @var int Affinity at which a player is treated as capable of a playstyle
+     *
+     * Affinities are the percentage of a player's past dominions flagged with a
+     * playstyle, so 50 means they have spent half their rounds doing it — enough
+     * to treat them as able and willing to do it again.
+     */
+    public const SPECIALIST_THRESHOLD = 50;
+
+    /**
+     * @var array Percentage of a realm's players that should be capable of each playstyle
+     *
+     * These are targets for the share of players clearing SPECIALIST_THRESHOLD, not
+     * average affinities. Playstyles are not mutually exclusive, so the values do not
+     * sum to 100 — one player can count toward several at once.
+     *
+     * Measured across the last three rounds: 174 users with computed affinities among
+     * the 190 distinct users who cleared protection. Setting the targets to the observed
+     * population shares keeps them achievable, so a balanced realm approaches zero
+     * deviation rather than carrying a permanent offset.
+     *
+     * Attacker and explorer swing by roughly 10 points between individual rounds, so
+     * these need re-measuring over several rounds rather than one, and a single round
+     * is not a safe basis for changing them.
      */
     public const IDEAL_COMPOSITION = [
-        'attackerAffinity' => 50,
-        'converterAffinity' => 30,
-        'explorerAffinity' => 50,
-        'opsAffinity' => 30,
+        'attackerAffinity' => 51,
+        'converterAffinity' => 25,
+        'explorerAffinity' => 55,
+        'opsAffinity' => 28,
     ];
+
+    /**
+     * @var float Scale applied to the playstyle term in getCompatibilityScore()
+     */
+    public const PLAYSTYLE_SCORE_WEIGHT = 1.0;
 
     public string $id;
     public Collection $players;
@@ -374,7 +380,6 @@ class PlaceholderRealm
             $totalScore += $favorabilityScore;
         }
 
-        // TODO: Weight this
         $totalScore += $this->calculatePlaystyleScore($players);
 
         return $totalScore;
@@ -384,8 +389,9 @@ class PlaceholderRealm
      * Calculate playstyle score for adding players to this realm
      *
      * Evaluates how adding players would move the realm closer to or further from
-     * the ideal playstyle composition. Players with unknown affinities are excluded
-     * from both the affinity totals and player counts.
+     * the ideal number of players capable of each playstyle. Players with unknown
+     * affinities are excluded from both the specialist counts and the targets those
+     * counts are measured against.
      *
      * @param Collection $players Players to evaluate for addition
      * @return float Balance improvement score (positive is better)
@@ -397,22 +403,27 @@ class PlaceholderRealm
             return 0.0;
         }
 
-        $currentComposition = $this->getPlaystyleCompositionFor($this->players);
-        $projectedComposition = $this->getPlaystyleCompositionFor(
-            $this->players->concat($knownIncomingPlayers)
+        $knownCurrentPlayers = $this->knownAffinityPlayers($this->players);
+        if ($knownCurrentPlayers->isEmpty()) {
+            // Nothing to improve on. Scoring an empty baseline would report the
+            // maximum possible improvement and swamp the size and rating terms.
+            return 0.0;
+        }
+
+        $currentDeviation = $this->calculatePlaystyleDeviation($knownCurrentPlayers);
+        $projectedDeviation = $this->calculatePlaystyleDeviation(
+            $knownCurrentPlayers->concat($knownIncomingPlayers)
         );
 
-        $currentDeviation = $this->calculatePlaystyleDeviation($currentComposition);
-        $projectedDeviation = $this->calculatePlaystyleDeviation($projectedComposition);
-
-        return $currentDeviation - $projectedDeviation;
+        return ($currentDeviation - $projectedDeviation) * static::PLAYSTYLE_SCORE_WEIGHT;
     }
 
     /**
      * Get realm's current playstyle composition as averages
      *
-     * Calculates the average playstyle affinity for each category across players with
-     * known profiles. Returns averages that can be directly compared to IDEAL_COMPOSITION.
+     * Reported in assignment statistics only. Scoring uses specialist counts instead,
+     * because averaging affinities across a realm cannot tell a realm of specialists
+     * apart from a realm of generalists — both average out to the same figures.
      *
      * @return array Associative array with playstyle averages (attackerAffinity, converterAffinity, etc.)
      */
@@ -422,23 +433,65 @@ class PlaceholderRealm
     }
 
     /**
-     * Calculate how far a composition deviates from ideal averages
+     * Count how many of the given players are capable of each playstyle
      *
-     * Measures the total absolute deviation from the ideal playstyle composition.
-     * Both composition and ideal values are averages, so direct comparison works.
-     * Lower values indicate better balance according to the configured ideal averages.
+     * A player counts toward a playstyle once their affinity reaches
+     * SPECIALIST_THRESHOLD. Playstyles are independent, so one player can count
+     * toward several at once.
      *
-     * @param array $composition Current playstyle averages
-     * @return float Total deviation from ideal (lower is better)
+     * Players with unknown affinities are filtered out here rather than by the caller:
+     * User::getAffinity() falls back to 50 for missing data, which clears the threshold
+     * and would silently count every unrated player as an attacker and an explorer.
+     *
+     * @param Collection $players Players to count
+     * @return array Associative array of playstyle => number of capable players
      */
-    private function calculatePlaystyleDeviation(array $composition): float
+    public function getSpecialistCounts(Collection $players): array
     {
-        $idealAverages = static::IDEAL_COMPOSITION;
-        $totalDeviation = 0;
+        $knownPlayers = $this->knownAffinityPlayers($players);
+        $counts = [];
 
-        foreach ($idealAverages as $style => $idealAverage) {
-            $actualAverage = $composition[$style] ?? 0;
-            $totalDeviation += abs($actualAverage - $idealAverage);
+        foreach (array_keys(static::IDEAL_COMPOSITION) as $style) {
+            $counts[$style] = $knownPlayers->filter(function (Player $player) use ($style): bool {
+                return $player->$style >= static::SPECIALIST_THRESHOLD;
+            })->count();
+        }
+
+        return $counts;
+    }
+
+    /**
+     * Report how far this realm's specialist mix sits from ideal
+     *
+     * The same figure the assignment scoring minimises, exposed for dry-run statistics.
+     * Zero means every playstyle is represented in its target proportion.
+     */
+    public function getPlaystyleDeviation(): float
+    {
+        return $this->calculatePlaystyleDeviation($this->players);
+    }
+
+    /**
+     * Calculate how far a set of players deviates from the ideal specialist mix
+     *
+     * Deviations are squared rather than absolute. Absolute deviation is linear below
+     * the target, so it scores an even split of a scarce playstyle identically to a
+     * stacked one — 3+1 and 2+2 both cost 3.20 against a target of 3.6. That is exactly
+     * the decision the assignment and swap passes make, and scarce playstyles sit below
+     * target almost always. Squaring makes the even split win.
+     *
+     * @param Collection $players Players with known affinities
+     * @return float Total squared deviation from ideal (lower is better)
+     */
+    private function calculatePlaystyleDeviation(Collection $players): float
+    {
+        $specialistCounts = $this->getSpecialistCounts($players);
+        $playerCount = $this->knownAffinityPlayers($players)->count();
+        $totalDeviation = 0.0;
+
+        foreach (static::IDEAL_COMPOSITION as $style => $idealPercentage) {
+            $target = $idealPercentage / 100 * $playerCount;
+            $totalDeviation += ($specialistCounts[$style] - $target) ** 2;
         }
 
         return $totalDeviation;
@@ -487,6 +540,16 @@ class RealmAssignmentService
      * @var int Number of hours before round start to begin realm assignment
      */
     public const ASSIGNMENT_HOURS_BEFORE_START = 96;
+
+    /**
+     * @var float Rating at or below which a player is treated as new
+     *
+     * User::getEffectiveRating() resolves an unrated user to User::DEFAULT_RATING, so
+     * the boundary must be inclusive — a player sitting exactly on it has no rating
+     * history to place them by. Comparisons against this value must be `<=` for new
+     * and `>` for experienced, so unrated players land on one side everywhere.
+     */
+    public const NEW_PLAYER_RATING = User::DEFAULT_RATING;
 
     /**
      * @var int Minimum number of realms to create
@@ -1039,14 +1102,15 @@ class RealmAssignmentService
      * Assign solo players to realms
      *
      * Orchestrates the assignment of individual players in two phases:
-     * Phase 1 distributes new players (rating=0) evenly using round-robin.
-     * Phase 2 assigns experienced players using full scoring with size constraints.
-     * This ensures fair distribution while optimizing for compatibility and balance.
+     * Phase 1 distributes new players (at or below NEW_PLAYER_RATING) evenly using
+     * round-robin. Phase 2 assigns experienced players using full scoring with size
+     * constraints. This ensures fair distribution while optimizing for compatibility
+     * and balance.
      */
     public function assignSolos(): void
     {
         // Phase 1: Distribute new players using round-robin
-        $newPlayers = $this->players->where('rating', '<=', 1000)->values(); // Get indexed collection
+        $newPlayers = $this->players->where('rating', '<=', self::NEW_PLAYER_RATING)->values(); // Get indexed collection
         $realmCount = $this->realms->count();
 
         // Assign all new players using round-robin across realms
@@ -1064,10 +1128,11 @@ class RealmAssignmentService
     /**
      * Assign experienced players using full scoring system
      *
-     * Assigns players with rating > 0 using comprehensive scoring that considers
-     * compatibility, balance, and size constraints. Players are sorted by rating
-     * (highest first) for strategic placement. Hard conflicts are avoided and
-     * the size penalty ensures equal distribution across realms.
+     * Assigns whichever players assignSolos() did not round-robin — those above
+     * NEW_PLAYER_RATING — using comprehensive scoring that considers compatibility,
+     * balance, and size constraints. Players are sorted by rating (highest first)
+     * for strategic placement. Hard conflicts are avoided and the size penalty
+     * ensures equal distribution across realms.
      */
     public function assignExperiencedPlayers(): void
     {
@@ -1119,8 +1184,8 @@ class RealmAssignmentService
             }
 
             // Find the best solo player to move (one that improves or least worsens rating balance)
-            // Prefer players rated > 1000, but fall back to any available solo player
-            $availablePlayers = $largest->soloPlayers()->where('rating', '>', 1000);
+            // Prefer experienced players, but fall back to any available solo player
+            $availablePlayers = $largest->soloPlayers()->where('rating', '>', self::NEW_PLAYER_RATING);
             if ($availablePlayers->isEmpty()) {
                 $availablePlayers = $largest->soloPlayers();
             }
@@ -1190,7 +1255,7 @@ class RealmAssignmentService
             // Collect all solo players with their realm assignments
             $soloPlayers = collect();
             foreach ($this->realms as $realm) {
-                foreach ($realm->soloPlayers()->where('rating', '>=', 1000) as $player) {
+                foreach ($realm->soloPlayers()->where('rating', '>', self::NEW_PLAYER_RATING) as $player) {
                     $soloPlayers->push([
                         'player' => $player,
                         'realm' => $realm
@@ -1387,26 +1452,35 @@ class RealmAssignmentService
      */
     public function getAssignmentStats(): array
     {
+        $styles = array_keys(PlaceholderRealm::IDEAL_COMPOSITION);
+        $shortNames = array_combine($styles, array_map(
+            fn ($style) => str_replace('Affinity', '', $style),
+            $styles
+        ));
+
         $stats = [
             'realm_count' => $this->realms->count(),
             'total_players' => 0,
             'total_new_players' => 0,
             'total_experienced_players' => 0,
+            'total_known_affinity_players' => 0,
             'average_realm_size' => 0,
             'average_realm_rating' => 0,
             'target_realm_strength' => $this->targetRealmStrength,
             'target_realm_size' => $this->targetRealmSize,
-            'overall_playstyle_distribution' => [
-                'attacker' => 0,
-                'converter' => 0,
-                'explorer' => 0,
-                'ops' => 0,
-            ],
+            'specialist_threshold' => PlaceholderRealm::SPECIALIST_THRESHOLD,
+            'ideal_specialist_distribution' => array_combine(
+                $shortNames,
+                array_values(PlaceholderRealm::IDEAL_COMPOSITION)
+            ),
+            'overall_specialist_distribution' => array_fill_keys(array_values($shortNames), 0),
+            'overall_playstyle_distribution' => array_fill_keys(array_values($shortNames), 0),
             'balance_metrics' => [
                 'size_variance' => 0,
                 'rating_variance' => 0,
                 'max_size_deviation' => 0,
                 'max_rating_deviation' => 0,
+                'max_playstyle_deviation' => 0,
             ],
             'realms' => []
         ];
@@ -1417,20 +1491,19 @@ class RealmAssignmentService
         $totalKnownAffinityPlayers = 0;
         $realmSizes = [];
         $realmRatings = [];
-        $totalPlaystyleAffinities = [
-            'attacker' => 0,
-            'converter' => 0,
-            'explorer' => 0,
-            'ops' => 0,
-        ];
+        $playstyleDeviations = [];
+        $totalPlaystyleAffinities = array_fill_keys($styles, 0);
+        $totalSpecialists = array_fill_keys($styles, 0);
 
         foreach ($this->realms as $realm) {
             $realmSize = $realm->size;
             $realmRating = $realm->rating;
             $playstyleDist = $realm->getPlaystyleComposition();
+            $specialistCounts = $realm->getSpecialistCounts($realm->players);
+            $playstyleDeviation = $realm->getPlaystyleDeviation();
             $knownAffinityPlayerCount = $realm->players->where('hasKnownAffinities', true)->count();
-            $newPlayerCount = $realm->players->where('rating', '<=', 1000)->count();
-            $experiencedPlayerCount = $realm->players->where('rating', '>', 1000)->count();
+            $newPlayerCount = $realm->players->where('rating', '<=', self::NEW_PLAYER_RATING)->count();
+            $experiencedPlayerCount = $realm->players->where('rating', '>', self::NEW_PLAYER_RATING)->count();
 
             // Accumulate totals
             $totalPlayers += $realmSize;
@@ -1439,23 +1512,32 @@ class RealmAssignmentService
             $totalKnownAffinityPlayers += $knownAffinityPlayerCount;
             $realmSizes[] = $realmSize;
             $realmRatings[] = $realmRating;
+            $playstyleDeviations[] = $playstyleDeviation;
 
-            // Accumulate playstyle affinities
-            $totalPlaystyleAffinities['attacker'] += $playstyleDist['attackerAffinity'] * $knownAffinityPlayerCount;
-            $totalPlaystyleAffinities['converter'] += $playstyleDist['converterAffinity'] * $knownAffinityPlayerCount;
-            $totalPlaystyleAffinities['explorer'] += $playstyleDist['explorerAffinity'] * $knownAffinityPlayerCount;
-            $totalPlaystyleAffinities['ops'] += $playstyleDist['opsAffinity'] * $knownAffinityPlayerCount;
+            // Averages are per known-affinity player, so weight them back up by that
+            // count rather than realm size before pooling them across realms.
+            foreach ($styles as $style) {
+                $totalPlaystyleAffinities[$style] += $playstyleDist[$style] * $knownAffinityPlayerCount;
+                $totalSpecialists[$style] += $specialistCounts[$style];
+            }
 
             $stats['realms'][] = [
                 'id' => $realm->id,
                 'size' => $realmSize,
-                'total_rating' => round($realm->rating, 2),
+                'total_rating' => round($realm->players->sum('rating'), 2),
                 'average_rating' => $realmRating,
                 'new_players' => $newPlayerCount,
                 'experienced_players' => $experiencedPlayerCount,
+                'known_affinity_players' => $knownAffinityPlayerCount,
                 'packed_players' => $realm->packedPlayerCount(),
                 'solo_players' => $realm->soloPlayers()->count(),
                 'playstyle_distribution' => $playstyleDist,
+                'specialist_counts' => array_combine($shortNames, array_values($specialistCounts)),
+                'specialist_targets' => array_combine($shortNames, array_map(
+                    fn ($ideal) => round($ideal / 100 * $knownAffinityPlayerCount, 2),
+                    array_values(PlaceholderRealm::IDEAL_COMPOSITION)
+                )),
+                'playstyle_deviation' => round($playstyleDeviation, 2),
                 'deviation_from_target_size' => round(abs($realmSize - $this->targetRealmSize), 2),
                 'deviation_from_target_rating' => round(abs($realmRating - $this->targetRealmStrength), 2),
             ];
@@ -1465,17 +1547,20 @@ class RealmAssignmentService
         $stats['total_players'] = $totalPlayers;
         $stats['total_new_players'] = $totalNewPlayers;
         $stats['total_experienced_players'] = $totalExperiencedPlayers;
+        $stats['total_known_affinity_players'] = $totalKnownAffinityPlayers;
         $stats['average_realm_size'] = $totalPlayers > 0 ? round($totalPlayers / $this->realms->count(), 2) : 0;
         $stats['average_realm_rating'] = count($realmRatings) > 0 ? round(array_sum($realmRatings) / count($realmRatings), 2) : 0;
 
-        // Calculate overall playstyle distribution
+        // Both distributions are per known-affinity player. The specialist shares are
+        // directly comparable to ideal_specialist_distribution and are what assignment
+        // actually optimises; the averages are reported for context only.
         if ($totalKnownAffinityPlayers > 0) {
-            $stats['overall_playstyle_distribution'] = [
-                'attacker' => round($totalPlaystyleAffinities['attacker'] / $totalKnownAffinityPlayers, 2),
-                'converter' => round($totalPlaystyleAffinities['converter'] / $totalKnownAffinityPlayers, 2),
-                'explorer' => round($totalPlaystyleAffinities['explorer'] / $totalKnownAffinityPlayers, 2),
-                'ops' => round($totalPlaystyleAffinities['ops'] / $totalKnownAffinityPlayers, 2),
-            ];
+            foreach ($styles as $style) {
+                $stats['overall_playstyle_distribution'][$shortNames[$style]] =
+                    round($totalPlaystyleAffinities[$style] / $totalKnownAffinityPlayers, 2);
+                $stats['overall_specialist_distribution'][$shortNames[$style]] =
+                    round(100 * $totalSpecialists[$style] / $totalKnownAffinityPlayers, 2);
+            }
         }
 
         // Calculate balance metrics
@@ -1491,6 +1576,7 @@ class RealmAssignmentService
                 'rating_variance' => round(array_sum($ratingVariances) / count($ratingVariances), 2),
                 'max_size_deviation' => round(max(array_map(fn ($size) => abs($size - $this->targetRealmSize), $realmSizes)), 2),
                 'max_rating_deviation' => round(max(array_map(fn ($rating) => abs($rating - $this->targetRealmStrength), $realmRatings)), 2),
+                'max_playstyle_deviation' => round(max($playstyleDeviations), 2),
             ];
         }
 
@@ -1553,15 +1639,23 @@ class RealmAssignmentService
             ->filter()
             ->values();
 
+        // Members are loaded by createPlaceholderRealm() instead of eager loaded here.
+        // A partial select of the users table would leave affinities missing and
+        // silently downgrade every member to unknown for playstyle scoring.
+        //
+        // The count drives both the smallest-realm ordering and the draft-pack
+        // comparison, so it has to mean "players still occupying a slot". Locked and
+        // abandoned dominions are not, and counting them makes a realm that needs
+        // players look full. Matches Round::activeDominions() and RaidService.
         $query = Realm::active()
             ->where('number', '!=', 0)
             ->where('round_id', $round->id)
-            ->withCount('dominions as active_dominions_count')
-            ->with(['dominions' => function ($query) {
-                $query->select('realm_id', 'user_id')
-                      ->with(['user' => function ($userQuery) {
-                          $userQuery->select('id', 'rating');
-                      }]);
+            ->withCount(['dominions as active_dominions_count' => function ($query) {
+                $query->whereNull('locked_at')
+                    ->where(function ($query) {
+                        $query->whereNull('abandoned_at')
+                            ->orWhere('abandoned_at', '>', now());
+                    });
             }]);
 
         // Apply alignment filtering if needed
@@ -1634,6 +1728,35 @@ class RealmAssignmentService
     }
 
     /**
+     * Load what existing players think of the incoming player
+     *
+     * getCompatibilityScore() sums favorability in both directions. Scoring with only
+     * the incoming player's own outbound feedback silently discards every downvote
+     * cast about them by the people already in the realm, which is the half that
+     * should keep them out.
+     *
+     * @param Player $player The incoming player
+     * @param Collection $candidateRealms Realms whose members may have rated them
+     * @return array Member user id => [incoming user id => score]
+     */
+    public function getInboundFavorability(Player $player, Collection $candidateRealms): array
+    {
+        $sourceUserIds = Dominion::whereIn('realm_id', $candidateRealms->pluck('id'))
+            ->pluck('user_id');
+
+        return UserFeedback::where('target_id', $player->userId)
+            ->whereIn('source_id', $sourceUserIds)
+            ->get()
+            ->groupBy('source_id')
+            ->mapWithKeys(function ($feedbacks, $sourceId) use ($player) {
+                $positive = $feedbacks->where('endorsed', true)->count();
+                $negative = $feedbacks->where('endorsed', false)->count();
+                return [$sourceId => [$player->userId => $positive - $negative]];
+            })
+            ->toArray();
+    }
+
+    /**
      * Select the best realm using compatibility and rating balance scoring
      */
     public function selectBestRealm(Collection $candidateRealms, Player $player, Round $round): ?Realm
@@ -1641,12 +1764,14 @@ class RealmAssignmentService
         // Calculate dynamic targets from all realms in the round
         $this->calculateDynamicTargets($round);
 
+        $inboundFavorability = $this->getInboundFavorability($player, $candidateRealms);
+
         $bestRealm = null;
         $bestScore = -INF;
 
         foreach ($candidateRealms as $realm) {
             // Create placeholder realm for scoring
-            $placeholderRealm = $this->createPlaceholderRealm($realm);
+            $placeholderRealm = $this->createPlaceholderRealm($realm, $inboundFavorability);
 
             // Calculate compatibility score using existing method
             $compatibilityScore = $placeholderRealm->getCompatibilityScore(collect([$player]));
@@ -1668,15 +1793,22 @@ class RealmAssignmentService
 
     /**
      * Convert a database Realm to PlaceholderRealm for scoring
+     *
+     * Loads the full user record for each member rather than reusing any partially
+     * selected relation, so affinities are present and the playstyle term scores the
+     * realm on real data instead of getAffinity()'s fallbacks.
+     *
+     * @param Realm $realm The realm to convert
+     * @param array $favorabilityByUserId Member user id => favorability map for that member
      */
-    public function createPlaceholderRealm(Realm $realm): PlaceholderRealm
+    public function createPlaceholderRealm(Realm $realm, array $favorabilityByUserId = []): PlaceholderRealm
     {
-        $players = $realm->dominions()->human()->get()->map(function ($dominion) {
+        $players = $realm->dominions()->human()->with('user')->get()->map(function ($dominion) use ($favorabilityByUserId) {
             return Player::fromUser($dominion->user, [
                 'id' => $dominion->user_id,
                 'userId' => $dominion->user_id,
                 'packId' => $dominion->pack_id,
-                'favorability' => [], // Not needed for existing players in this context
+                'favorability' => $favorabilityByUserId[$dominion->user_id] ?? [],
             ]);
         });
 

--- a/src/Services/RealmAssignmentService.php
+++ b/src/Services/RealmAssignmentService.php
@@ -2,6 +2,8 @@
 
 namespace OpenDominion\Services;
 
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Support\Collection;
 use OpenDominion\Factories\RealmFactory;
 use OpenDominion\Models\Dominion;
@@ -1630,6 +1632,27 @@ class RealmAssignmentService
      * every other realm has at least 2 more total players — in which case the draft-pack
      * realm is the least-loaded option and should be considered.
      */
+    /**
+     * Constrain a dominion query to members still occupying a realm slot
+     *
+     * Locked and abandoned dominions are not coming back, so they must not count
+     * toward a realm's size, rating, playstyle composition, or favorability. Every
+     * membership query in the findRealm path routes through here so the definition
+     * cannot drift between them — filtering the size count but not the scoring would
+     * let a realm rank as small and still be scored as though it were full.
+     *
+     * Abandonment is scheduled 24h ahead, so a future abandoned_at is still active.
+     * Matches Round::activeDominions(), RaidService and TickService.
+     */
+    private function scopeOccupiedSlots(Builder|Relation $query): Builder|Relation
+    {
+        return $query->whereNull('locked_at')
+            ->where(function (Builder $query) {
+                $query->whereNull('abandoned_at')
+                    ->orWhere('abandoned_at', '>', now());
+            });
+    }
+
     public function getCandidateRealms(Round $round, Race $race): Collection
     {
         // Find realm IDs that contain a draft pack
@@ -1650,12 +1673,8 @@ class RealmAssignmentService
         $query = Realm::active()
             ->where('number', '!=', 0)
             ->where('round_id', $round->id)
-            ->withCount(['dominions as active_dominions_count' => function ($query) {
-                $query->whereNull('locked_at')
-                    ->where(function ($query) {
-                        $query->whereNull('abandoned_at')
-                            ->orWhere('abandoned_at', '>', now());
-                    });
+            ->withCount(['dominions as active_dominions_count' => function (Builder $query) {
+                $this->scopeOccupiedSlots($query);
             }]);
 
         // Apply alignment filtering if needed
@@ -1704,7 +1723,7 @@ class RealmAssignmentService
     {
         // Get all dominion IDs in candidate realms
         $candidateRealmIds = $candidateRealms->pluck('id');
-        $targetUserIds = Dominion::whereIn('realm_id', $candidateRealmIds)
+        $targetUserIds = $this->scopeOccupiedSlots(Dominion::whereIn('realm_id', $candidateRealmIds))
             ->pluck('user_id')
             ->toArray();
 
@@ -1741,7 +1760,7 @@ class RealmAssignmentService
      */
     public function getInboundFavorability(Player $player, Collection $candidateRealms): array
     {
-        $sourceUserIds = Dominion::whereIn('realm_id', $candidateRealms->pluck('id'))
+        $sourceUserIds = $this->scopeOccupiedSlots(Dominion::whereIn('realm_id', $candidateRealms->pluck('id')))
             ->pluck('user_id');
 
         return UserFeedback::where('target_id', $player->userId)
@@ -1803,7 +1822,9 @@ class RealmAssignmentService
      */
     public function createPlaceholderRealm(Realm $realm, array $favorabilityByUserId = []): PlaceholderRealm
     {
-        $players = $realm->dominions()->human()->with('user')->get()->map(function ($dominion) use ($favorabilityByUserId) {
+        $members = $this->scopeOccupiedSlots($realm->dominions()->human())->with('user')->get();
+
+        $players = $members->map(function ($dominion) use ($favorabilityByUserId) {
             return Player::fromUser($dominion->user, [
                 'id' => $dominion->user_id,
                 'userId' => $dominion->user_id,
@@ -1828,7 +1849,9 @@ class RealmAssignmentService
     {
         $realms = Realm::where('round_id', $round->id)
             ->where('number', '!=', 0)
-            ->withCount('dominions')
+            ->withCount(['dominions' => function (Builder $query) {
+                $this->scopeOccupiedSlots($query);
+            }])
             ->get(['id', 'rating']);
 
         $realmCount = $realms->count();

--- a/src/Services/RealmAssignmentService.php
+++ b/src/Services/RealmAssignmentService.php
@@ -969,7 +969,18 @@ class RealmAssignmentService
         PlaceholderRealm $realm
     ): float {
         $placementScore = $this->calculatePlacementScore($realm, $pack->members);
-        $opportunityCost = $this->calculateOpportunityCost($realm, $pack, $placementScore);
+
+        // Opportunity cost compares two packs competing for the SAME realm, so both
+        // would collect that realm's identical size bonus and it says nothing about
+        // which pack deserves the slot. Comparing a size-inclusive current score
+        // against size-free rival scores left the bonus behind on every iteration,
+        // scaling it by however many rival packs happened to fit — a realm with more
+        // pack headroom had its size term multiplied by (1 + 0.3 * rivals).
+        $opportunityCost = $this->calculateOpportunityCost(
+            $realm,
+            $pack,
+            $this->calculatePlacementScore($realm, $pack->members, false)
+        );
 
         return $placementScore + $opportunityCost;
     }
@@ -1057,26 +1068,33 @@ class RealmAssignmentService
     /**
      * Calculate size bonus/penalty for realm assignments
      *
-     * Provides a large penalty (-1000) for realms at or above target size to
-     * enforce equal distribution. Realms below target receive a small bonus
-     * proportional to how many players they need. This ensures all realms
-     * reach approximately the same size.
+     * Scored on the size the realm would have *after* the placement, so a pack that
+     * would overshoot the target is penalised before it lands rather than on the next
+     * placement. Realms below target receive a small bonus proportional to how many
+     * players they still need.
+     *
+     * The over-target penalty is large enough to remove a realm from contention —
+     * it dominates realistic compatibility and balance scores by an order of
+     * magnitude — but it grows with the overshoot rather than being a flat cliff.
+     * targetRealmSize is floor(players / realms), so whenever players do not divide
+     * evenly some realms must exceed the target; a flat penalty made a realm of 40
+     * indistinguishable from one of 13 and let placements land on the worst of them.
      *
      * @param PlaceholderRealm $realm The realm to evaluate
-     * @return float Size bonus/penalty (-1000 for full realms, positive for others)
+     * @param int $incomingPlayers How many players the placement would add
+     * @return float Size bonus/penalty (large negative when over target)
      */
-    public function calculateSizeBonus(PlaceholderRealm $realm): float
+    public function calculateSizeBonus(PlaceholderRealm $realm, int $incomingPlayers): float
     {
-        $currentSize = $realm->players->count();
+        $projectedSize = $realm->players->count() + $incomingPlayers;
         $targetSize = $this->targetRealmSize;
 
-        // Tiered penalty/bonus system for balanced distribution
-        if ($currentSize > $targetSize) {
-            return -5000; // Strong penalty for exceeding limit
+        if ($projectedSize > $targetSize) {
+            return -5000 - ($projectedSize - $targetSize) * 100;
         }
 
         // Moderate bonus for realms under ideal size
-        return ($targetSize - $currentSize) * 10;
+        return ($targetSize - $projectedSize) * 10;
     }
 
     /**
@@ -1095,7 +1113,7 @@ class RealmAssignmentService
     {
         $compatibilityScore = $realm->getCompatibilityScore($players);
         $balanceScore = $this->calculateBalanceScore($realm, $players);
-        $sizeBonus = $includeSize ? $this->calculateSizeBonus($realm) : 0;
+        $sizeBonus = $includeSize ? $this->calculateSizeBonus($realm, $players->count()) : 0;
 
         return $compatibilityScore + $balanceScore + $sizeBonus;
     }

--- a/tests/AbstractTestCase.php
+++ b/tests/AbstractTestCase.php
@@ -11,7 +11,6 @@ abstract class AbstractTestCase extends TestCase
 {
     use CreatesApplication;
     use CreatesData;
-
     /**
      * Roll back everything each test writes.
      *

--- a/tests/AbstractTestCase.php
+++ b/tests/AbstractTestCase.php
@@ -2,6 +2,7 @@
 
 namespace OpenDominion\Tests;
 
+use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Illuminate\Foundation\Testing\TestCase;
 use OpenDominion\Tests\Traits\CreatesApplication;
 use OpenDominion\Tests\Traits\CreatesData;
@@ -10,4 +11,15 @@ abstract class AbstractTestCase extends TestCase
 {
     use CreatesApplication;
     use CreatesData;
+
+    /**
+     * Roll back everything each test writes.
+     *
+     * Without this the suite leaves its rows behind, and UserFactory's
+     * faker->unique() only dedupes within a single run — so duplicate email
+     * collisions become steadily more likely as the database fills up.
+     * DatabaseTransactions rather than RefreshDatabase, because the suite reads
+     * seeded reference data (races, units, spells) that a fresh migration drops.
+     */
+    use DatabaseTransactions;
 }

--- a/tests/Unit/Services/PlaceholderRealmTest.php
+++ b/tests/Unit/Services/PlaceholderRealmTest.php
@@ -2,6 +2,7 @@
 
 namespace OpenDominion\Tests\Unit\Services;
 
+use Illuminate\Support\Collection;
 use OpenDominion\Models\User;
 use OpenDominion\Services\PlaceholderRealm;
 use OpenDominion\Services\Player;
@@ -10,6 +11,19 @@ use PHPUnit\Framework\TestCase;
 
 class PlaceholderRealmTest extends TestCase
 {
+    /**
+     * Player, PlaceholderPack and PlaceholderRealm are all declared inside
+     * RealmAssignmentService.php, so PSR-4 cannot resolve them by name and the
+     * `use` statements above are not enough to load them. Referencing the one
+     * class that does match its filename pulls the whole file in.
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        class_exists(RealmAssignmentService::class);
+    }
+
     public function testPlayerFactoryMarksMissingAndZeroAffinitiesUnknown(): void
     {
         $missingAffinitiesUser = new User();
@@ -48,21 +62,79 @@ class PlaceholderRealmTest extends TestCase
         ], $realm->getPlaystyleComposition());
     }
 
-    public function testProjectedCompositionUsesAWeightedAverage(): void
+    public function testSpecialistAndGeneralistRealmsAreScoredDifferently(): void
     {
-        $existingPlayers = collect();
-        foreach (range(1, 9) as $id) {
-            $existingPlayers->push($this->knownPlayer("existing-{$id}", [40, 30, 50, 30]));
-        }
+        // Both realms average to an identical composition, so scoring on average
+        // affinity cannot tell them apart -- but one has a dedicated ops player
+        // and a dedicated converter, and the other has nobody who does either.
+        $specialists = new PlaceholderRealm('specialists', collect([
+            $this->knownPlayer('s1', [100, 0, 100, 0]),
+            $this->knownPlayer('s2', [100, 0, 100, 0]),
+            $this->knownPlayer('s3', [0, 100, 0, 0]),
+            $this->knownPlayer('s4', [0, 20, 0, 100]),
+        ]));
+        $generalists = new PlaceholderRealm('generalists', collect([
+            $this->knownPlayer('g1', [50, 30, 50, 25]),
+            $this->knownPlayer('g2', [50, 30, 50, 25]),
+            $this->knownPlayer('g3', [50, 30, 50, 25]),
+            $this->knownPlayer('g4', [50, 30, 50, 25]),
+        ]));
 
-        $realm = new PlaceholderRealm('test', $existingPlayers);
-        $incomingPlayer = $this->knownPlayer('incoming', [100, 30, 50, 30]);
-
-        $this->assertEqualsWithDelta(
-            6.0,
-            $realm->calculatePlaystyleScore(collect([$incomingPlayer])),
-            0.0001
+        $this->assertSame(
+            $specialists->getPlaystyleComposition(),
+            $generalists->getPlaystyleComposition(),
+            'the two realms must be indistinguishable by average affinity'
         );
+
+        $opsPlayer = $this->knownPlayer('ops', [20, 20, 20, 90]);
+
+        // The realm with no ops player wants one; the realm that already has one
+        // does not. The average-based score returned exactly 0 for both.
+        $this->assertGreaterThan(
+            $specialists->calculatePlaystyleScore(collect([$opsPlayer])),
+            $generalists->calculatePlaystyleScore(collect([$opsPlayer]))
+        );
+    }
+
+    public function testScarcePlaystyleIsSpreadRatherThanStacked(): void
+    {
+        // Ops target is 30% of realm size, so both realms sit below it. Absolute
+        // deviation improves by exactly 0.7 for either placement and cannot pick
+        // between them; squared deviation prefers the realm with fewer.
+        $fewer = new PlaceholderRealm('fewer', $this->realmWithOpsSpecialists(1));
+        $more = new PlaceholderRealm('more', $this->realmWithOpsSpecialists(2));
+
+        $opsPlayer = $this->knownPlayer('ops', [20, 20, 20, 90]);
+
+        $this->assertGreaterThan(
+            $more->calculatePlaystyleScore(collect([$opsPlayer])),
+            $fewer->calculatePlaystyleScore(collect([$opsPlayer]))
+        );
+    }
+
+    public function testSpecialistCountsTreatPlaystylesAsIndependent(): void
+    {
+        $realm = new PlaceholderRealm('test', collect([
+            $this->knownPlayer('both', [80, 10, 10, 80]),
+            $this->knownPlayer('neither', [49, 49, 49, 49]),
+        ]));
+
+        $this->assertSame([
+            'attackerAffinity' => 1,
+            'converterAffinity' => 0,
+            'explorerAffinity' => 0,
+            'opsAffinity' => 1,
+        ], $realm->getSpecialistCounts($realm->players));
+    }
+
+    /**
+     * Ten players identical but for ops, so only the ops counts differ.
+     */
+    private function realmWithOpsSpecialists(int $count): Collection
+    {
+        return collect(range(1, 10))->map(function (int $id) use ($count): Player {
+            return $this->knownPlayer("p{$id}", [60, 20, 60, $id <= $count ? 90 : 10]);
+        });
     }
 
     public function testUnknownIncomingPlayersDoNotChangeIdealOrNonIdealRealmScores(): void

--- a/tests/Unit/Services/RealmAssignmentServiceTest.php
+++ b/tests/Unit/Services/RealmAssignmentServiceTest.php
@@ -1304,6 +1304,52 @@ class RealmAssignmentServiceTest extends AbstractTestCase
         $this->assertTrue($selected->is($neutralRealm));
     }
 
+    public function testRealmMembershipConsistentlyExcludesLockedAndAbandonedDominions(): void
+    {
+        $round = $this->createRound();
+        $realm = $this->createRealm($round);
+
+        $active = $this->createUser(null, ['rating' => 1500]);
+        $this->createDominion($active, $round, null, $realm);
+
+        $locked = $this->createUser(null, ['rating' => 1500]);
+        $this->createDominion($locked, $round, null, $realm)
+            ->update(['locked_at' => now()->subDay()]);
+
+        $abandoned = $this->createUser(null, ['rating' => 1500]);
+        $this->createDominion($abandoned, $round, null, $realm)
+            ->update(['abandoned_at' => now()->subHour()]);
+
+        // Scheduled abandonment has not taken effect yet, so this one still counts.
+        $leaving = $this->createUser(null, ['rating' => 1500]);
+        $this->createDominion($leaving, $round, null, $realm)
+            ->update(['abandoned_at' => now()->addDay()]);
+
+        $newcomer = $this->createUser(null, ['rating' => 1500]);
+        foreach ([$locked, $abandoned] as $departed) {
+            UserFeedback::create([
+                'source_id' => $departed->id,
+                'target_id' => $newcomer->id,
+                'round_id' => $round->id,
+                'endorsed' => false,
+            ]);
+        }
+
+        $placeholderRealm = $this->service->createPlaceholderRealm($realm);
+        $player = Player::fromUser($newcomer, ['id' => $newcomer->id, 'userId' => $newcomer->id]);
+
+        $this->assertSame(
+            2,
+            $placeholderRealm->players->count(),
+            'only the active and not-yet-abandoned members occupy a slot'
+        );
+        $this->assertSame(
+            [],
+            $this->service->getInboundFavorability($player, collect([$realm])),
+            'feedback from departed members must not follow a newcomer around'
+        );
+    }
+
     public function testPlaceholderRealmLoadsAffinitiesForExistingMembers(): void
     {
         $round = $this->createRound();

--- a/tests/Unit/Services/RealmAssignmentServiceTest.php
+++ b/tests/Unit/Services/RealmAssignmentServiceTest.php
@@ -7,6 +7,7 @@ use OpenDominion\Models\Pack;
 use OpenDominion\Models\Race;
 use OpenDominion\Models\Round;
 use OpenDominion\Models\User;
+use OpenDominion\Models\UserFeedback;
 use OpenDominion\Services\PlaceholderPack;
 use OpenDominion\Services\PlaceholderRealm;
 use OpenDominion\Services\Player;
@@ -1240,5 +1241,86 @@ class RealmAssignmentServiceTest extends AbstractTestCase
             $compatibilityScore - $playstyleScore,
             'Feedback should match user IDs even when dominion IDs differ'
         );
+    }
+
+    public function testInboundFavorabilityLoadsWhatExistingMembersThinkOfTheNewcomer(): void
+    {
+        $round = $this->createRound();
+        $realm = $this->createRealm($round);
+
+        $critic = $this->createUser(null, ['rating' => 1500]);
+        $this->createDominion($critic, $round, null, $realm);
+
+        $newcomer = $this->createUser(null, ['rating' => 1500]);
+        UserFeedback::create([
+            'source_id' => $critic->id,
+            'target_id' => $newcomer->id,
+            'round_id' => $round->id,
+            'endorsed' => false,
+        ]);
+
+        $player = Player::fromUser($newcomer, ['id' => $newcomer->id, 'userId' => $newcomer->id]);
+
+        $this->assertSame(
+            [$critic->id => [$newcomer->id => -1]],
+            $this->service->getInboundFavorability($player, collect([$realm]))
+        );
+    }
+
+    public function testSelectBestRealmAvoidsRealmsWhoseMembersDownvotedTheNewcomer(): void
+    {
+        $round = $this->createRound();
+        $hostileRealm = $this->createRealm($round);
+        $neutralRealm = $this->createRealm($round);
+
+        $newcomer = $this->createUser(null, ['rating' => 1500]);
+
+        // Both realms are identical in size, rating and affinities, so the only
+        // thing that can separate them is feedback the newcomer never gave.
+        foreach ([$hostileRealm, $neutralRealm] as $realm) {
+            foreach (range(1, 2) as $ignored) {
+                $member = $this->createUser(null, ['rating' => 1500]);
+                $this->createDominion($member, $round, null, $realm);
+
+                if ($realm->is($hostileRealm)) {
+                    UserFeedback::create([
+                        'source_id' => $member->id,
+                        'target_id' => $newcomer->id,
+                        'round_id' => $round->id,
+                        'endorsed' => false,
+                    ]);
+                }
+            }
+        }
+
+        $player = Player::fromUser($newcomer, ['id' => $newcomer->id, 'userId' => $newcomer->id]);
+
+        $selected = $this->service->selectBestRealm(
+            collect([$hostileRealm, $neutralRealm]),
+            $player,
+            $round
+        );
+
+        $this->assertTrue($selected->is($neutralRealm));
+    }
+
+    public function testPlaceholderRealmLoadsAffinitiesForExistingMembers(): void
+    {
+        $round = $this->createRound();
+        $realm = $this->createRealm($round);
+
+        $member = $this->createUser(null, [
+            'rating' => 1500,
+            'affinities' => ['attacker' => 80, 'converter' => 10, 'explorer' => 20, 'ops' => 10],
+        ]);
+        $this->createDominion($member, $round, null, $realm);
+
+        $player = $this->service->createPlaceholderRealm($realm)->players->first();
+
+        $this->assertTrue(
+            $player->hasKnownAffinities,
+            'existing members must reach playstyle scoring with their real affinities'
+        );
+        $this->assertSame(80.0, $player->attackerAffinity);
     }
 }

--- a/tests/Unit/Services/RealmAssignmentServiceTest.php
+++ b/tests/Unit/Services/RealmAssignmentServiceTest.php
@@ -1243,6 +1243,104 @@ class RealmAssignmentServiceTest extends AbstractTestCase
         );
     }
 
+    private function scoringPlayer(string $id, float $rating = 1500, ?string $packId = null): Player
+    {
+        return new Player([
+            'id' => $id,
+            'userId' => $id,
+            'rating' => $rating,
+            'packId' => $packId,
+            'hasKnownAffinities' => false,
+        ]);
+    }
+
+    private function scoringRealm(string $id, int $size, float $rating = 1500, bool $packed = false): PlaceholderRealm
+    {
+        return new PlaceholderRealm($id, collect(range(1, $size))->map(
+            fn (int $i) => $this->scoringPlayer("{$id}_{$i}", $rating, $packed ? 'seed' : null)
+        ));
+    }
+
+    private function scoringPack(string $id, int $size, float $rating = 1500): PlaceholderPack
+    {
+        return new PlaceholderPack($id, collect(range(1, $size))->map(
+            fn (int $i) => $this->scoringPlayer("{$id}_{$i}", $rating, $id)
+        ));
+    }
+
+    public function testSizeBonusPenalisesAPlacementThatWouldOvershootTheTarget(): void
+    {
+        $this->service->targetRealmSize = 12;
+        $realm = $this->scoringRealm('realm', 8);
+
+        // One more player still fits; a six player pack would land the realm on 14.
+        $this->assertGreaterThan(0, $this->service->calculateSizeBonus($realm, 1));
+        $this->assertLessThan(
+            -5000,
+            $this->service->calculateSizeBonus($realm, 6),
+            'the penalty must fire before the pack lands, not on the next placement'
+        );
+    }
+
+    public function testSizeBonusRanksTheLeastOverTargetRealmHighest(): void
+    {
+        $this->service->targetRealmSize = 12;
+
+        // targetRealmSize is floor(players / realms), so some realms must exceed it.
+        // A flat penalty made all of these identical.
+        $previous = null;
+        foreach ([13, 18, 25, 40] as $size) {
+            $bonus = $this->service->calculateSizeBonus($this->scoringRealm("size-{$size}", $size), 0);
+
+            $this->assertLessThan(-5000, $bonus);
+            if ($previous !== null) {
+                $this->assertLessThan($previous, $bonus, 'a fuller realm must score worse');
+            }
+            $previous = $bonus;
+        }
+    }
+
+    public function testOverTargetRealmLosesToAnUnderTargetRealmEvenWhenItIsABetterRatingFit(): void
+    {
+        $this->service->targetRealmSize = 12;
+        $this->service->targetRealmStrength = 1500;
+
+        $pack = $this->scoringPack('subject', 2, 2400);
+        $overTarget = $this->scoringRealm('over', 13, 900);   // adding the pack improves its rating
+        $underTarget = $this->scoringRealm('under', 4, 2400); // adding the pack worsens its rating
+
+        $this->assertGreaterThan(
+            $this->service->calculatePlacementScore($overTarget, $pack->members),
+            $this->service->calculatePlacementScore($underTarget, $pack->members),
+            'the size penalty must outweigh a favourable rating balance'
+        );
+    }
+
+    public function testOpportunityCostDoesNotScaleWithTheRealmSizeBonus(): void
+    {
+        $this->service->targetRealmSize = 12;
+        $this->service->targetRealmStrength = 1500;
+
+        $pack = $this->scoringPack('subject', 2);
+        $this->service->packs = collect(['subject' => $pack]);
+        foreach (range(1, 5) as $i) {
+            $this->service->packs->put("rival-{$i}", $this->scoringPack("rival-{$i}", 2));
+        }
+
+        // Identical size, so an identical size bonus. Rival packs are identical to the
+        // subject, so every opportunity cost term is zero and cannot separate them —
+        // the only difference is how many rivals canFitPack() admits.
+        $roomy = $this->scoringRealm('roomy', 8);
+        $stuffed = $this->scoringRealm('stuffed', 8, 1500, true);
+
+        $this->assertEqualsWithDelta(
+            $this->service->evaluatePackPlacement($pack, $stuffed),
+            $this->service->evaluatePackPlacement($pack, $roomy),
+            0.0001,
+            'the size bonus must count once, not once per rival pack that happens to fit'
+        );
+    }
+
     public function testInboundFavorabilityLoadsWhatExistingMembersThinkOfTheNewcomer(): void
     {
         $round = $this->createRound();


### PR DESCRIPTION
## Summary

Playstyle balancing in realm assignment was scoring realms on **average affinity**, which cannot distinguish a realm of specialists from a realm of generalists — both average to identical figures. This replaces it with specialist headcount against per-realm targets, recalibrates those targets against production data, and fixes several surrounding bugs found while working in the file.

## Why the old scoring did nothing

Two independent problems cancelled the term out entirely.

**1. The target was the population mean.** `IDEAL_COMPOSITION` was calibrated to average player affinity, so any random partition already hits it in expectation. Simulating a random assignment with no playstyle optimisation at all:

```
deviation-from-ideal   min=15.1  max=36.8   (out of a possible 160)
```

Random assignment was already ~85% of the way to "ideal" for free. The marginal effect of one player on that was ~6 points, against a size bonus spanning 70 and a balance score spanning ~100 — i.e. noise.

**2. Averaging discards the signal.** Two realms, one with a dedicated ops player and a dedicated converter, one where four identical generalists dabble in everything:

```
identical average composition: {"attacker":50,"converter":30,"explorer":50,"ops":25}
```

Byte-identical, so both scored the same. `calculateAffinities()` returns *the percentage of your past dominions flagged with a playstyle*, so an ops average of 30 across 12 players could be four dedicated ops players or twelve part-timers. Very different realms to play in.

## Changes

### Playstyle scoring: specialist counts, not average affinity

- `SPECIALIST_THRESHOLD = 50` — a player counts toward a playstyle once they've spent half their past rounds doing it. Playstyles are independent, so one player can count toward several.
- `IDEAL_COMPOSITION` keeps its shape but now means *percentage of a realm's players that should be capable*, not mean affinity.
- Deviation is now measured in specialist headcount against `pct × realmSize`.

Same example under the new scoring:

```
specialists (has an ops player)    ops specialists 1   score for incoming ops player:  -1.23
generalists (has none)             ops specialists 0   score for incoming ops player:  +3.95
```

### Squared deviation, not absolute

Absolute deviation is linear below the target, so redistributing a scarce specialist between two under-target realms changes nothing — and scarce playstyles sit below target almost always. With an ops target of 3.6 in a 12-player realm:

```
realm counts 3 and 1 ->  absolute 3.20   squared 7.12
realm counts 2 and 2 ->  absolute 3.20   squared 5.12
```

That is exactly the decision `assignExperiencedPlayers()` and `shouldSwapSolos()` make. Squaring makes the even split win. There's a regression test pinning this.

### Recalibrated `IDEAL_COMPOSITION` against production

Measured as the share of players clearing threshold 50, over users whose dominions cleared protection (`protection_finished`, matching `ValorCalculator`'s definition of a real participant):

| | round A (n=119) | round B (n=147) | **pooled 3 rounds (n=174)** |
|---|---|---|---|
| attacker | 63.9% | 52.4% | **51.1%** |
| converter | 32.8% | 26.5% | **25.3%** |
| explorer | 42.9% | 53.7% | **54.6%** |
| ops | 29.4% | 30.6% | **28.2%** |

Attacker and explorer swing ~11pp in opposite directions between consecutive rounds — real meta variation, not sampling noise — so **a single round is not a safe basis for these constants**. Committed values are the pooled figures: `51 / 25 / 55 / 28`. Noted in the docblock so nobody recalibrates from one round.

Setting targets to observed population shares also keeps them achievable, so a balanced realm approaches zero deviation instead of carrying a permanent offset — the dry-run number is now readable as a quality score.

### Resolved `// TODO: Weight this`

Replaced with a measured `PLAYSTYLE_SCORE_WEIGHT = 1.0`. At that weight the term spreads 6.5–13.3 across realms depending on the incoming player, against ~70 for the size bonus and ~100 for balance — a genuine tiebreaker between realms close on size and rating, without overriding either. It's loudest when placing a scarce ops specialist and quietest for a generalist, which is the intended behaviour.

### Rating threshold consistency

`User::DEFAULT_RATING` is 1000 and `getEffectiveRating()` maps unrated users onto it, but the four comparison sites straddled that value: `optimizeAssignments()` used `>= 1000` while everything else treated 1000 as "new". Unrated players were round-robined as newcomers by one pass and pulled into the swap pool by another.

All four now use `NEW_PLAYER_RATING = User::DEFAULT_RATING`, with `<=` for new and `>` for experienced. This also restores pre-normalisation behaviour, matching the intent of "narrow unrated defaults to rating handling". Stale docblocks claiming `rating=0` / `rating > 0` updated — they stopped being true when the code moved to 1000.

### `findRealm` now scores inbound favorability

`getCompatibilityScore()` sums favorability in **both** directions, but `createPlaceholderRealm()` passed `'favorability' => []` for existing members. Only the newcomer's own outbound feedback counted, so downvotes cast *about* them by people already in the realm were silently discarded — the half that should keep them out.

New `getInboundFavorability()` loads that side once per registration and passes it in. Regression test verified to fail without the fix.

### Locked and abandoned dominions excluded from every membership query

`Realm::dominions()` is an unfiltered `hasMany`, so `active_dominions_count` included locked and abandoned dominions despite the alias. It drives both the smallest-realm ordering and the draft-pack comparison, so a realm carrying abandoned dominions looked fuller than it was and registrants were steered away from a realm that needed them.

Filtering that count alone would have split the `findRealm` path against itself — the realm would rank as small and win a candidate slot, then be scored as though the departed members were still there, padding its size, skewing its average rating, contributing specialist counts toward playstyle coverage it doesn't have, and letting a departed player's downvote still block a newcomer. All five membership queries in the path now route through one private helper so the definition can't drift between them:

| query | feeds |
|---|---|
| `getCandidateRealms` | candidate ordering, draft-pack comparison |
| `createPlaceholderRealm` | size, rating, playstyle, favorability |
| `getInboundFavorability` | downvotes against the newcomer |
| `createPlayerForUser` | which feedback to load |
| `calculateDynamicTargets` | `targetRealmSize` |

The filter is `locked_at IS NULL` and `abandoned_at IS NULL OR abandoned_at > now()`, matching `Round::activeDominions()`, `RaidService` and `TickService`. The `> now()` half matters because abandonment is scheduled 24h ahead, so a dominion with a future `abandoned_at` is still playing.

The bulk assignment path is unaffected: `loadPlayers()` uses `activeDominions()` and only reads realm 0, where locked and abandoned dominions don't yet exist. This matters most for registrations *during* a round, when departed players accumulate.

### Size penalty now measures what it was meant to measure

The size term is meant to remove a realm from contention once it's very full compared to the others. The magnitude was already doing that — an over-target realm loses by ~4,700 even when it's a perfect rating fit — but two details stopped it measuring the right thing.

**It scored the current size, not the projected one.** A six-player pack landing a realm on 14 against a target of 12 collected a `+40` *reward*; the `-5000` only fired on the next placement, after the overshoot. Reachable in the normal pack path whenever `targetRealmSize` drops below `MAX_PACKED_PLAYERS_PER_REALM` — any round under roughly 64 players — and in the `assignPack()` fallback that discards size restrictions when no realm fits.

**The penalty was a flat cliff.** `targetRealmSize` is `floor(players / realms)`, so whenever players don't divide evenly some realms *must* exceed the target — being over target is the normal end state, not an exception. A flat `-5000` made these indistinguishable:

```
before:  13 -> -5000   18 -> -5000   25 -> -5000   40 -> -5000
after:   13 -> -5300   18 -> -5800   25 -> -6500   40 -> -8000
```

Once several realms were over, size stopped ordering them at all and a marginal compatibility edge could send the next pack to the fullest realm.

**The size bonus leaked into opportunity cost.** That comparison weighs two packs competing for the *same* realm, so both would collect that realm's identical size bonus — it says nothing about which deserves the slot and should cancel. Comparing a size-inclusive current score against size-free rival scores left it behind on every iteration, scaled by however many rivals happened to fit:

```
two realms, identical size 8, identical +40 size bonus:
  0 packed players (5 rival packs fit)  -> +100.00
  8 packed players (0 rival packs fit)  ->  +40.00
```

`S × (1 + 0.3 × rivals)`. Both sides are size-free now, so the bonus counts exactly once.

### Query hygiene in the `findRealm` path

- `createPlaceholderRealm()` eager loads `user` — was N+1, one query per member per candidate realm per registration.
- Removed the unused partial eager load in `getCandidateRealms()`. It selected only `id, rating` from users, was never consumed (the method re-queries), and would have silently downgraded every member to unknown-affinity if anyone had "optimised" the re-query away. Comment left explaining why it's absent.

### Assignment statistics

- `known_affinity_players` per realm — `playstyle_distribution` was an average over an unreported subset, so a realm with 1 known member read identically to one with 12.
- `specialist_counts` and `specialist_targets` side by side, plus `playstyle_deviation` — what the scoring actually optimises, so a dry run shows whether balancing worked.
- Top level: `specialist_threshold`, `ideal_specialist_distribution` and `overall_specialist_distribution` (directly comparable), `total_known_affinity_players`, and `max_playstyle_deviation`.
- **Bug:** `total_rating` was reporting `round($realm->rating, 2)` — the *average*, byte-identical to `average_rating` beside it. Now the actual sum.
- **Bug:** `getSpecialistCounts()` didn't filter by `hasKnownAffinities`, and unknown players carry `getAffinity()`'s fallback of 50, which *clears* the threshold. Calling it from the stats would have counted every unrated player as both an attacker and an explorer. Now filters internally. Scoring was never affected — it only ever passed pre-filtered players.

### Test autoloading

`PlaceholderRealmTest` had **5 of its 6 tests erroring** with `Class ... not found`. `Player`, `PlaceholderPack` and `PlaceholderRealm` are declared inside `RealmAssignmentService.php`, so PSR-4 cannot resolve them by name and a `use` statement doesn't autoload. It passed in full-suite runs only because some earlier test happened to load the file first — pure ordering luck. Added a `setUp()` that references the one autoloadable class, with a docblock so it isn't deleted as a no-op.

### Removed `getPrimaryPlaystyle()`

Dead code, called nowhere. It returned `'attacker'` for anyone with unknown affinities because all four `getAffinity()` fallbacks tie at 50.

## Behaviour changes

- Realm assignment will produce **different groupings** — the playstyle term now influences placement where it previously contributed noise.
- Unrated players are no longer eligible for optimisation swaps (restores prior behaviour).
- Registrants may be routed to realms that previously looked full due to locked/abandoned dominions.
- `getAssignmentStats()` gained keys and changed `total_rating`'s meaning. Only consumed by the dry-run path and tests.

## Testing

21 tests across the two realm assignment files, up from 16 (of which 5 never ran). New coverage:

- specialist and generalist realms with identical averages score differently
- scarce playstyles are spread rather than stacked (the squared-deviation case)
- specialist counts treat playstyles as independent
- inbound favorability loads what existing members think of a newcomer
- `selectBestRealm` avoids realms whose members downvoted the newcomer — **verified to fail without the fix**
- existing members reach playstyle scoring with real affinities
- realm membership consistently excludes locked and abandoned dominions, and keeps a dominion whose abandonment is merely scheduled — **verified to fail without the fix** (counted 4 members instead of 2)
- the size penalty fires before a pack overshoots the target — **verified to fail without the fix**
- over-target realms are ranked by how far over they are — **verified to fail without the fix**
- opportunity cost doesn't scale with the realm's size bonus — **verified to fail without the fix**
- an over-target realm still loses to an under-target one even when it's the better rating fit (characterisation test — this already held, and now can't drift)

Full `--testsuite=Unit`: 407 passing, 0 failing.

This branch also adds `DatabaseTransactions` to `AbstractTestCase`. The suite previously left its rows behind — `UserFactory` relies on faker's `unique()`, which only dedupes within a single run, so duplicate-email collisions grew steadily likelier as the database filled (a Unit run added ~81 users; it now adds ~4). That is the "flaky factory collision" behind cd85f0752. `DatabaseTransactions` rather than `RefreshDatabase`, because the suite reads seeded reference data that a fresh migration drops.

## Follow-ups not in this PR

- **Bots in `active_dominions_count`.** The count includes bot dominions while `createPlaceholderRealm()` filters to `human()`, so a realm's size and its compatibility score disagree about who lives there. Correct fix depends on whether bots share numbered realms with humans — no such data locally, so left alone.
- **Pool-derived targets.** Fixed constants can't tell an attacker-heavy round from an explorer-heavy one, and the swing between two consecutive rounds exceeded the correction made here. Deriving targets from each round's registrant pool would adapt automatically; the scoring shape wouldn't change, only where the targets come from.
- **Genuinely 1000-rated vs unrated players are indistinguishable**, since `getEffectiveRating()` maps both to the same number. Fixing it means threading a `hasRating` flag through `Player` the way `hasKnownAffinities` already is — a behaviour change to who gets round-robined, not a bug fix.
