### PR TITLE
Hourly tick performance: benchmarking harness, profiling image, and measured optimisations

### DIFF
--- a/app/database/migrations/2026_08_14_120000_add_daily_rankings_round_key_value_index.php
+++ b/app/database/migrations/2026_08_14_120000_add_daily_rankings_round_key_value_index.php
@@ -1,0 +1,40 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    /**
+     * Supports the ranking window in TickService::updateDailyRankings().
+     *
+     * The table previously carried only unique(dominion_id, key) and the
+     * round_id foreign-key index, so ranking a round had nothing to seek on.
+     *
+     * Column order follows what the statement needs: round_id is the only
+     * equality predicate and the table accumulates every round ever played;
+     * key is the window's partition; value is its sort key; rank is included
+     * purely so the derived table can be served index-only, since it selects
+     * id, rank, key and value, and InnoDB appends the primary key.
+     *
+     * The same index serves the leaderboard reads in RankingsController and
+     * ValhallaController::getDominionsByRanking(), which filter on
+     * round_id + key and order by value.
+     */
+    public function up(): void
+    {
+        Schema::table('daily_rankings', function (Blueprint $table) {
+            $table->index(['round_id', 'key', 'value', 'rank'], 'daily_rankings_round_key_value_rank_idx');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('daily_rankings', function (Blueprint $table) {
+            $table->dropIndex('daily_rankings_round_key_value_rank_idx');
+        });
+    }
+};

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -82,6 +82,14 @@ services:
   # last left behind. The dev database currently carries orphan rounds leaked by
   # a crashing suite, three of which start at the same hour and so change what
   # tickDaily() does depending on the time of day.
+  #
+  # This database is for `dev:tick:profile`, and is expected to hold a large
+  # persistent round so profiling runs are fast and reproducible. Do NOT run the
+  # PHPUnit suite against it while that fixture is loaded: UserFactory's
+  # faker->unique() only dedupes within one process, so a few hundred seeded
+  # users make email collisions likely (see the note in tests/AbstractTestCase).
+  # Run tests against the app service, or reset this database first with
+  # `migrate:fresh --seed`.
   mariadb-benchmark:
     image: 'mariadb:10.11'
     profiles:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,9 @@ services:
     build:
       context: .
       dockerfile: docker/Dockerfile
+      # Pinned because the Dockerfile is multi-stage: without a target Docker
+      # builds the last stage, which would ship the profilers in this image.
+      target: app
     image: opendominion-app
     ports:
       - '${APP_PORT:-80}:80'
@@ -38,6 +41,67 @@ services:
     networks:
       - opendominion
 
+  # Profiling environment. Behind a compose profile, so `docker compose up -d`
+  # still brings up exactly what it did before - app and mariadb, nothing else.
+  # Reach it with `docker compose run --rm benchmark <command>`, which activates
+  # the profile automatically.
+  benchmark:
+    build:
+      context: .
+      dockerfile: docker/Dockerfile
+      target: benchmark
+    image: opendominion-benchmark
+    profiles:
+      - benchmark
+    # The image ENTRYPOINT is docker/entrypoint.sh, which bootstraps Apache and
+    # is in any case unrunnable from a Windows checkout (it is LF in git's index
+    # but CRLF in the working tree, so it dies with `env: 'bash\r'`). The base
+    # PHP image's entrypoint just execs its arguments, which is what a CLI
+    # container wants.
+    entrypoint: ['/usr/local/bin/docker-php-entrypoint']
+    command: ['sleep', 'infinity']
+    volumes:
+      - '.:/var/www/html'
+      # Shared with the app service so this image needs no separate install.
+      - 'opendominion-vendor:/var/www/html/vendor'
+    environment:
+      # These win over the bind-mounted .env: Laravel's Dotenv repository is
+      # immutable, so a real environment variable takes precedence.
+      DB_HOST: mariadb-benchmark
+      DB_PORT: 3306
+      DB_DATABASE: '${BENCHMARK_DB_DATABASE:-opendominion_benchmark}'
+      DB_USERNAME: '${DB_USERNAME:-opendominion}'
+      DB_PASSWORD: '${DB_PASSWORD:-secret}'
+    depends_on:
+      mariadb-benchmark:
+        condition: service_healthy
+    networks:
+      - opendominion
+
+  # Dedicated database so measurements do not depend on what the test suites
+  # last left behind. The dev database currently carries orphan rounds leaked by
+  # a crashing suite, three of which start at the same hour and so change what
+  # tickDaily() does depending on the time of day.
+  mariadb-benchmark:
+    image: 'mariadb:10.11'
+    profiles:
+      - benchmark
+    environment:
+      MYSQL_ROOT_PASSWORD: '${DB_PASSWORD:-secret}'
+      MYSQL_ROOT_HOST: '%'
+      MYSQL_DATABASE: '${BENCHMARK_DB_DATABASE:-opendominion_benchmark}'
+      MYSQL_USER: '${DB_USERNAME:-opendominion}'
+      MYSQL_PASSWORD: '${DB_PASSWORD:-secret}'
+    volumes:
+      - 'opendominion-mariadb-benchmark:/var/lib/mysql'
+    healthcheck:
+      test: ['CMD', 'mysqladmin', 'ping', '-uroot', '-p${DB_PASSWORD:-secret}']
+      retries: 5
+      interval: 5s
+      timeout: 5s
+    networks:
+      - opendominion
+
   mariadb:
     image: 'mariadb:10.11'
     ports:
@@ -64,6 +128,8 @@ networks:
 
 volumes:
   opendominion-mariadb:
+    driver: local
+  opendominion-mariadb-benchmark:
     driver: local
   opendominion-vendor:
     driver: local

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,10 @@
 FROM node:18 AS node
 
-FROM php:8.5-apache
+# Everything shared by the runtime image and the benchmarking image. Split into
+# stages rather than a second Dockerfile because a standalone file doing
+# `FROM opendominion-app` would depend on build ordering, which Compose does not
+# guarantee between services.
+FROM php:8.5-apache AS base
 
 # System dependencies for PHP extensions and tooling
 RUN apt-get update && apt-get install -y \
@@ -48,3 +52,21 @@ WORKDIR /var/www/html
 EXPOSE 80
 
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
+
+# The image the app service runs. Identical to what this Dockerfile produced
+# before it was split; the compose service pins `target: app` so that adding
+# stages below cannot silently ship a profiler into the runtime image.
+FROM base AS app
+
+# Profiling image, used only by the benchmark service.
+#
+# excimer is a sampling profiler: near-zero overhead, answers "where does wall
+# time go". xdebug answers "how many times was this called", but slows
+# execution by 10-50x, so benchmark.ini leaves it switched off and it is opted
+# into per run with XDEBUG_MODE=profile.
+FROM base AS benchmark
+
+RUN pecl install excimer xdebug \
+ && docker-php-ext-enable excimer xdebug
+
+COPY docker/benchmark.ini /usr/local/etc/php/conf.d/zz-benchmark.ini

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -53,20 +53,23 @@ EXPOSE 80
 
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
 
-# The image the app service runs. Identical to what this Dockerfile produced
-# before it was split; the compose service pins `target: app` so that adding
-# stages below cannot silently ship a profiler into the runtime image.
-FROM base AS app
-
 # Profiling image, used only by the benchmark service.
 #
 # excimer is a sampling profiler: near-zero overhead, answers "where does wall
 # time go". xdebug answers "how many times was this called", but slows
 # execution by 10-50x, so benchmark.ini leaves it switched off and it is opted
 # into per run with XDEBUG_MODE=profile.
+#
+# Deliberately NOT the last stage: a bare `docker build -f docker/Dockerfile .`
+# builds whichever stage comes last, and that must be the runtime image. Anything
+# wanting this one asks for it by name with `--target benchmark`.
 FROM base AS benchmark
 
 RUN pecl install excimer xdebug \
  && docker-php-ext-enable excimer xdebug
 
 COPY docker/benchmark.ini /usr/local/etc/php/conf.d/zz-benchmark.ini
+
+# The image the app service runs, and the default for any consumer that does not
+# name a target. Identical to what this Dockerfile produced before it was split.
+FROM base AS app

--- a/docker/benchmark.ini
+++ b/docker/benchmark.ini
@@ -1,0 +1,27 @@
+; PHP settings for the benchmarking image only (docker/Dockerfile, stage
+; `benchmark`). The runtime image does not load this file.
+
+; Xdebug is installed but inert. Its instrumentation costs 10-50x, which would
+; make every wall-time measurement meaningless, so it stays off and is opted
+; into per run:
+;
+;   docker compose run --rm -e XDEBUG_MODE=profile benchmark \
+;       php artisan dev:tick:profile
+;
+; mode=off is what makes it inert; start_with_request must stay `yes` or the
+; profiler never actually starts once a mode IS selected, and the opt-in above
+; silently produces no output.
+xdebug.mode = off
+xdebug.start_with_request = yes
+xdebug.output_dir = /var/www/html/storage/profiles
+
+; excimer needs no ini configuration; the sampling period is set in code.
+
+; Profiling a round of a few hundred dominions exceeds the default 128M.
+memory_limit = 3G
+
+; Profiling output is otherwise buried under thousands of deprecation notices
+; from Faker's property-style accessors and implicit float-to-int conversions
+; in DominionFactory. Suppressed here so profiler output is readable; the app
+; image still reports them.
+error_reporting = E_ALL & ~E_DEPRECATED

--- a/firstroundfindings.txt
+++ b/firstroundfindings.txt
@@ -1,0 +1,481 @@
+================================================================================
+OpenDominion Hourly Tick - Performance Review
+================================================================================
+
+Scope:  game:tick -> TickService::tickHourly() and everything it reaches, plus
+        the calculator/model layer it drives.
+Method: static analysis of the call graph. No .env is present in this checkout,
+        so profiling against a live database was not possible - all quantities
+        below are derived by hand-tracing the code and are marked as estimates
+        where that matters.
+
+Let N = active dominions in a round (real players + ~80% NPDs, so realistically
+4-8x the human player count).
+
+
+================================================================================
+1. HOW THE TICK IS STRUCTURED TODAY
+================================================================================
+
+TickService::performTick() (src/Services/Dominion/TickService.php:265) is
+genuinely well-designed at the top:
+
+Phase A - bulk SQL (fast, correct).
+    One UPDATE ... JOIN dominion_tick applying ~70 pre-computed deltas for the
+    whole round, plus one UPDATE dominion_spells and one UPDATE dominion_queue,
+    all in a single transaction (lines 282-381). This is the right shape and is
+    not where the time goes.
+
+Phase B - per-dominion PHP loop (lines 417-433).
+    For every dominion: a DB::transaction, spell cleanup, queue cleanup,
+    precalculateTick(), and notification dispatch.
+
+Essentially all the cost is Phase B. Phase A is O(1) statements; Phase B is O(N)
+statements AND O(N) heavy PHP. The pre-calculation architecture was clearly
+built to make Phase A cheap, but Phase B was never given the same treatment.
+
+
+================================================================================
+2. TIER 1 - STRUCTURAL FINDINGS (LARGEST WINS)
+================================================================================
+
+--------------------------------------------------------------------------------
+2.1 precalculateTick() issues ~20 queries per dominion, mostly re-fetching data
+    the tick already loaded
+--------------------------------------------------------------------------------
+
+performTick() eager-loads a good relation set for all dominions at once
+(lines 395-409): queues, race.*, spells, techs.perks, tick, user, cached round.
+
+Then precalculateTick() (line 962), for EACH dominion, throws most of it away:
+
+    // TickService.php:1018-1028
+    foreach (['queues', 'spells', 'techs', 'hero', 'realm'] as $rel) {
+        $dominion->unsetRelation($rel);
+    }
+    $dominion->load([
+        'queues', 'spells', 'spells.perks', 'techs', 'techs.perks',
+        'hero', 'hero.upgrades', 'realm.wonders', 'realm.wonders.perks',
+    ]);
+
+load() (unlike loadMissing()) always re-queries. Per dominion that's ~9-10
+SELECTs. Adding the rest of the method:
+
+    Query                              Line    Count
+    ---------------------------------------------------
+    Tick::firstOrCreate                965     1
+    HistoryService::record insert      985     1
+    fresh-row refetch                  1007    1
+    load([...])                        1022    ~9-10
+    getActiveSpells()                  1040    ~3
+    incoming-queue select              1043    1
+    Valuable count (via spy regen)     -       1
+    expiring-spells select             1147    1
+    $tick->save()                      1152    1
+
+~19-20 queries x N. At N = 1,500 that is roughly 30,000 round-trips in the loop,
+against 3 statements in Phase A.
+
+Two things make this worse than it looks:
+
+  - The realm relations are re-fetched per dominion, not per realm. 12-15
+    dominions in a realm each independently load the same realm,
+    realm.wonders, realm.wonders.perks.
+
+  - The eager-load in performTick() is largely wasted - it pays to load
+    queues/spells/techs for everyone, then discards and re-loads them one at
+    a time.
+
+The unsetRelation + fresh-refetch is deliberate and correct - the comments at
+lines 1004-1017 explain it guards the ACTION-REQUEST path (via DominionSaved)
+against a tick landing mid-request. But the TICK path has the opposite
+guarantee: performTick() has just done the authoritative write and knows state
+is current. It does not need per-dominion re-reads.
+
+RECOMMENDATION
+    Give precalculateTick() a `bool $reloadState = true` parameter. In the tick
+    loop, pass false and instead re-hydrate in chunks after cleanup -
+    Dominion::whereIn('id', $chunkIds)->with([...])->withCachedRace()
+    ->withCachedRound()->get() for chunks of ~200. Query count drops from ~20N
+    to roughly 2N + 10*(N/200) (the Tick upsert and history insert still being
+    per-dominion until 2.4 below). The listener path keeps its current
+    behaviour unchanged.
+
+--------------------------------------------------------------------------------
+2.2 Queue and spell cleanup are per-dominion; they should be per-round
+--------------------------------------------------------------------------------
+
+cleanupActiveSpells() (line 899) and cleanupQueues() (line 931) each run a
+SELECT and a DELETE per dominion - 4N statements - and only exist to collect
+notification payloads before deleting.
+
+Worse, cleanupActiveSpells has a nested N+1:
+
+    // TickService.php:901-907
+    $finished = DominionSpell::query()
+        ->where('dominion_id', $dominion->id)
+        ->where('duration', '<=', 0)
+        ->get()
+        ->map(function ($dominionSpell) {
+            return $dominionSpell->spell;   // lazy belongsTo - one query per row
+        });
+
+spells is a small static reference table. Every expiring spell row costs a
+fresh SELECT.
+
+RECOMMENDATION
+    Both are trivially batchable:
+      - One SELECT ... WHERE dominion_id IN (chunk) AND duration <= 0, grouped
+        in PHP by dominion_id, with spells resolved from a
+        Spell::all()->keyBy('id') cached once per tick (mirroring the existing
+        Race::findWithRelationsCached / Round::findCached pattern).
+      - One SELECT + one DELETE for queues over the same chunk.
+
+    4N + (expiring spell count) statements -> ~4 per chunk.
+
+--------------------------------------------------------------------------------
+2.3 Every perk lookup rebuilds a collection from scratch
+--------------------------------------------------------------------------------
+
+This is the single largest CPU item, and it is in Dominion itself:
+
+    // Dominion.php:731-742
+    public function getSpellPerks() {
+        return $this->spells->flatMap(function ($spell) {
+            return $spell->perks->map(function ($perk) use ($spell) {
+                $perk->category = $spell->category;   // also mutates the model
+                return $perk;
+            });
+        });
+    }
+
+    // Dominion.php:749-765
+    public function getSpellPerkValue(string $key, array $types = ['self','friendly']): float
+    {
+        $perks = $this->getSpellPerks()->whereIn('category', $types)->groupBy('key');
+        ...
+    }
+
+Nothing is memoized. Every call does a full flatMap + attribute write +
+whereIn + groupBy over all spells x perks. getTechPerkValue (line 788) and
+getWonderPerkValue (line 822) have the identical shape.
+
+The multiplier is SpellCalculator::resolveSpellPerk() (SpellCalculator.php:254),
+which calls getSpellPerkValue() FIVE TO SIX TIMES for one logical lookup. And
+ProductionCalculator alone calls resolveSpellPerk ~10 times per pre-calculation
+(platinum, food, food consumption, wizard-guild mana, mana, mana decay, ore,
+gems, tech, boats), each expanding to 5-6 full rebuilds.
+
+Counting only ProductionCalculator, that's ~50 full spell-perk collection
+rebuilds per dominion; across PopulationCalculator, MilitaryCalculator, and
+NetworthCalculator the real figure is in the LOW HUNDREDS PER DOMINION PER TICK.
+
+Side note on the `$perk->category = $spell->category` write: it mutates a shared
+Eloquent model to smuggle a value through, marking it dirty. It works, but it's
+the kind of thing that produces a surprising "Unknown column 'category'" if one
+of those models is ever saved.
+
+RECOMMENDATION
+    Memoize per-dominion, keyed on a cheap fingerprint of the relation:
+
+        protected ?array $spellPerkCache = null;
+
+    built once (a flat ['category' => ['key' => value]] array, not a
+    Collection), invalidated in unsetRelation/setRelation for
+    spells/techs/realm. Because the tick and the request path both re-hydrate
+    relations explicitly, invalidation points are few and well-defined. The
+    "TODO: Group by category and remove resolveSpellPerk" already sitting at
+    Dominion.php:751 is the same idea - a category-keyed map makes
+    resolveSpellPerk one array read instead of six rebuilds.
+
+    This is a pure-compute change with no schema or query impact, and it
+    benefits every page render as much as the tick.
+
+--------------------------------------------------------------------------------
+2.4 Calculator fan-out: the same values are recomputed 10x per dominion
+--------------------------------------------------------------------------------
+
+PopulationCalculator::getPopulationPeasantGrowth() (PopulationCalculator.php:350):
+
+    $maximumPeasantDeath  = round(-0.05 * $dominion->peasants - $this->getPopulationDrafteeGrowth($dominion));
+    ...
+    $roomForPeasants      = ($this->getMaxPopulation($dominion) - $this->getPopulation($dominion) - $this->getPopulationDrafteeGrowth($dominion));
+    $currentPopulationChange = ($this->getPopulationBirth($dominion) - $this->getPopulationDrafteeGrowth($dominion));
+
+getPopulationDrafteeGrowth() is called 4 TIMES (the fourth via
+getPopulationBirthRaw). Each one calls getPopulationMilitaryPercentage ->
+getPopulation + getPopulationMilitary, i.e. 2 getPopulationMilitary calls each.
+Add getMaxPopulation -> getMaxPopulationMilitaryBonus -> one more, and the
+direct getPopulation.
+
+~10 getPopulationMilitary() calls for one line of tick output.
+
+And getPopulationMilitary (line 101) is not cheap:
+
+    + $this->militaryCalculator->getTotalUnitsForSlot($dominion, 1)   // -> queue scan
+    + ... slots 2, 3, 4                                               // -> 3 more
+    + $this->queueService->getTrainingQueueTotal($dominion)           // -> another
+
+Each getTotalUnitsForSlot -> getInvasionQueueTotalByResource ->
+QueueService::getQueue (QueueService.php:47), which does
+->where('source',...)->where('hours','>',...) on the in-memory collection, then
+a filter and a sum - FOUR NEW COLLECTION ALLOCATIONS PER CALL, over the
+dominion's full queue set.
+
+~50 full scans of $dominion->queues, ~200 Collection allocations, for peasant
+growth alone. The queue data is immutable for the duration of one
+precalculateTick.
+
+RECOMMENDATION
+    Two independent options, either helps:
+
+      - Local memoization inside getPopulationPeasantGrowth - hoist
+        $drafteeGrowth, $populationMilitary, $population into locals. This is a
+        ~10-line, zero-risk change to a single method and removes the bulk of
+        the redundancy.
+
+      - A per-tick queue index. QueueService already has a forTick flag toggled
+        around the calculation (TickService.php:989-993, 1154-1158). That's a
+        natural place to also build a [source][resource] => amount array once
+        per dominion and serve getQueueTotalBy* from it, instead of re-scanning.
+
+
+================================================================================
+3. TIER 2 - DISCRETE WASTE (SMALL DIFFS, REAL SAVINGS)
+================================================================================
+
+3.1 A DISCARDED QUERY, xN.
+    TickService.php:1040:
+
+        $this->spellCalculator->getActiveSpells($dominion);
+
+    The return value is never assigned. getActiveSpells
+    (SpellCalculator.php:172) runs DominionSpell::with(['castByDominion',
+    'spell'])...->get() - ~3 queries, thrown away. $dominion->spells was
+    already loaded 18 lines above. DELETE THE LINE (worth confirming against
+    git log that it wasn't a deliberate cache-warm; nothing in the current code
+    reads from it).
+
+3.2 A Valuable COUNT PER DOMINION.
+    MilitaryCalculator::getSpyStrengthRegen() (MilitaryCalculator.php:1016) runs
+    a Valuable::query()->where(...)->count(). Called once per dominion per
+    pre-calculation. The index ['source_dominion_id','status'] exists, so each
+    is cheap, but it's N ROUND-TRIPS. In the tick, fetch investigating-valuable
+    counts for the whole round in one grouped query and pass them in (or attach
+    as a relation).
+
+3.3 USER-AGENT PARSING PER DOMINION.
+    precalculateTick -> HistoryService::record() (line 98) ->
+    ActivityService::getDeviceString() (line 38), which does `new Agent` and
+    $agent->browser() / platform() / version(). In a console context
+    request()->userAgent() is NULL, not 'Symfony/3.X', so the early-out at
+    ActivityService.php:44 DOES NOT FIRE and jenssegers/agent (Mobile_Detect)
+    runs its full regex battery - N TIMES PER TICK - to produce a device string
+    for a row nobody attributes to a browser. Broaden the guard to:
+
+        if ($userAgent === null || $userAgent === 'Symfony/3.X' || app()->runningInConsole())
+
+3.4 DominionSaved FIRES INSIDE THE TICK AND DUPLICATES THE WORK.
+    In performSpellEffects() (line 762), the Cull-the-Weak / Death-and-Decay /
+    Dark-Elf branches each call $dominionSpell->dominion->update([...]). Every
+    update() dispatches DominionSavedEvent -> DominionSaved::handle()
+    (src/Listeners/DominionSaved.php:19) -> a full networth recalculation AND a
+    full precalculateTick(). The main loop then runs precalculateTick() on the
+    same dominion again minutes later. Affected dominions pay for it twice.
+    Suppress the listener for the duration of the tick
+    (Dominion::withoutEvents(...) around performSpellEffects, or a TickService
+    re-entrancy flag), since performTick pre-calculates everything afterwards
+    anyway.
+
+3.5 N+1s INSIDE performSpellEffects.
+    Three near-identical blocks (lines 787, 813, 830) do:
+
+        $dominionSpells = DominionSpell::whereIn('spell_id', $spellIds)
+            ->whereIn('dominion_id', $dominionIds)->get();
+        foreach ($dominionSpells as $dominionSpell) {
+            $totalLand = $this->landCalculator->getTotalLand($dominionSpell->dominion);   // lazy belongsTo
+            $perk = $dominionSpell->spell->perks()->where('key', ...)->first();           // 2 more queries
+
+    ->with(['dominion', 'spell.perks']) on the outer query removes all of them.
+    Also, $dominionSpell->dominion->update() triggers Dominion::save(), whose
+    "verify tick hasn't happened" guard (Dominion.php:454-459) adds ANOTHER
+    SELECT per save because no 'protection' option is passed.
+
+3.6 LOADING EVERY DOMINION MODEL TO LOG A COUNT.
+    Lines 386 and 438:
+
+        number_format($round->activeDominions->count())
+
+    The dynamic property hydrates the entire activeDominions collection - full
+    model objects for the whole round - purely to log a number. The second one
+    is 30 lines below where $dominions already exists. Use $dominions->count(),
+    and $round->activeDominions()->count() for the first.
+
+3.7 tickDaily() EAGER-LOADS ALL DOMINIONS AND NEVER USES THEM.
+    Line 726:
+
+        foreach (Round::with('dominions')->active()->get() as $round) {
+
+    The body uses $round->start_date, $round->realms(), $round->dominions()
+    (a FRESH QUERY BUILDER, not the loaded relation), and $round->daysInRound().
+    The with('dominions') hydrates thousands of models that are never read.
+    DROP IT.
+
+3.8 SAME PATTERN IN RaidService::updateActivePlayerCounts()
+    (src/Services/RaidService.php:114): ->with(['dominions.user']) is loaded,
+    then every count is computed via a fresh $realm->dominions() query with a
+    whereHas. The eager load is dead weight, and $realms->fresh() at line 133
+    re-loads them all a second time to compute an average that could come from
+    the counts already in hand.
+
+3.9 ONE TRANSACTION PER DOMINION.
+    Line 418 opens a DB::transaction(..., 5) inside the loop - N x BEGIN/COMMIT.
+    Once cleanup is batched (2.2) and pre-calculation is chunked (2.1), this
+    naturally becomes one transaction per chunk.
+
+
+================================================================================
+4. TIER 3 - SQL AND SCHEMA
+================================================================================
+
+--------------------------------------------------------------------------------
+4.1 The daily-rankings self-join is quadratic and unindexed
+--------------------------------------------------------------------------------
+
+TickService::updateDailyRankings() (line 1228):
+
+    $ranks = DB::table('daily_rankings AS a')
+        ->select(DB::raw('a.*, COUNT(b.value)+1 AS new_rank'))
+        ->leftJoin('daily_rankings AS b', function ($join) use ($round) {
+            $join->on('a.value', '<', 'b.value');
+            $join->on('a.key', '=', 'b.key');
+            $join->where('b.round_id', $round->id);
+        })
+        ->where('a.round_id', $round->id)
+        ->groupBy('a.dominion_id', 'a.key', 'a.value')
+
+daily_rankings carries only unique(['dominion_id','key'])
+(2020_04_09_182859_refactor_daily_rankings.php:22) - NO INDEX ON
+(round_id, key, value). So this is a range self-join with nothing to seek on.
+With ~20 ranking keys and N dominions, the table holds ~20N rows and the join
+compares on the order of 20 x N^2 row pairs. At N = 1,500 that's ~45 MILLION
+comparisons in one statement.
+
+RECOMMENDATION
+    Replace with a window function (MySQL 8 / MariaDB 10.2+ both support it):
+
+        RANK() OVER (PARTITION BY `key` ORDER BY value DESC)
+
+    One sorted pass instead of a self-join, and it fixes the ranking semantics
+    too - the current COUNT(b.value)+1 is a RANK() (ties share a rank, gaps
+    follow), which is probably intended, but it's implicit. Add
+    index(['round_id','key','value']) regardless; it helps the leaderboard
+    reads as well.
+
+    This runs inside DailyRankingsAndStatsJob, so with a live worker it's off
+    the tick's critical path - but the job is dispatched at the same instant
+    the tick starts (TickCommand.php:36), so it contends for the same database.
+
+--------------------------------------------------------------------------------
+4.2 daily_rankings upsert is unbounded
+--------------------------------------------------------------------------------
+
+Line 1221 upserts the entire $statistics array - up to 20N rows - in a single
+statement, and line 1248 does the same for ranks. That's one very large packet
+that will hit max_allowed_packet as rounds grow. Chunk at ~1,000 rows.
+
+--------------------------------------------------------------------------------
+4.3 dominion_tick.dominion_id should be UNIQUE
+--------------------------------------------------------------------------------
+
+2019_08_04_210813_create_dominion_tick_table.php:74 adds only a foreign key.
+The relationship is 1:1 (Dominion::tick() is a hasOne, and
+Tick::firstOrCreate(['dominion_id' => ...]) assumes uniqueness). Two risks: a
+duplicate row would silently DOUBLE-APPLY every delta in the Phase-A join at
+line 285, and firstOrCreate has a race window with no constraint to catch it.
+Adding unique('dominion_id') closes both and makes the tick's join lookup a
+single-row seek.
+
+
+================================================================================
+5. TIER 4 - OPERATIONAL
+================================================================================
+
+5.1 NO OVERLAP GUARD ON THE TICK.
+    src/Console/Kernel.php:18:
+
+        $schedule->command('game:tick')->hourlyAt(0);
+
+    There is no ->withoutOverlapping(). If a tick ever exceeds one hour, a
+    second one starts on top of it and Phase A's dominions + dominion_tick
+    deltas apply TWICE - silent duplicate resource grants. Given that the loop
+    is the part that scales with player count, this is the failure mode the
+    current design is most exposed to. ->withoutOverlapping(120) is a one-line
+    insurance policy and I'd apply it regardless of whether anything else here
+    is done.
+
+5.2 LONG TRANSACTIONS BLOCK LIVE PLAYERS.
+    Phase A wraps three round-wide UPDATEs in one transaction, and
+    performRaceUnitProduction() (line 851) wraps a loop over EVERY dominion -
+    including resolveSpellPerk, military calculations, and one upsert per
+    dominion - in a single transaction (line 853). Every row touched holds a
+    lock for the whole duration. This is the mechanism behind the
+    'The Emperor is currently collecting taxes...' GameException at
+    Dominion.php:457. Shortening the loop directly shortens the window players
+    are locked out.
+
+5.3 YOU ARE FLYING WITH TWO DATA POINTS.
+    The only instrumentation is two Log::info timings (lines 384 and 436)
+    covering "the bulk update" and "everything else". The second covers cleanup
+    + pre-calculation + notifications as one number, so it can't tell you which
+    of them is the cost. Before acting on any of the above, add per-phase timers
+    and wrap the tick in DB::listen() under a debug flag to get an actual query
+    count per phase - it converts every estimate in this report into a
+    measurement.
+
+
+================================================================================
+6. SUGGESTED ORDER OF WORK
+================================================================================
+
+Sequenced by return-on-risk, not by size:
+
+ #  Change                                                    Risk     Expected effect
+ -- --------------------------------------------------------- -------- ------------------------------------------
+ 1  withoutOverlapping() on game:tick (5.1)                   none     correctness insurance
+ 2  Per-phase timing + DB::listen() query counts (5.3)        none     turns estimates into data
+ 3  Delete the discarded getActiveSpells() call (3.1)         none     -3N queries
+ 4  Drop unused eager loads in tickDaily /                    none     removes two full-round hydrations
+    updateActivePlayerCounts (3.7, 3.8)
+ 5  Console guard in getDeviceString() (3.3)                  none     -N Mobile_Detect runs
+ 6  Hoist repeated calls in                                   low      ~10x -> 1x on the heaviest population path
+    getPopulationPeasantGrowth (2.4)
+ 7  Batch cleanupActiveSpells / cleanupQueues (2.2)           low      4N + spell-N statements -> ~4/chunk
+ 8  with() fixes + withoutEvents in                           low      removes double pre-calculation
+    performSpellEffects (3.4, 3.5)
+ 9  Window-function ranking +                                 low      quadratic -> linear-ish
+    (round_id,key,value) index (4.1)
+10  Memoize perk lookups on Dominion (2.3)                    medium   hundreds of rebuilds -> one per dominion;
+                                                                       also speeds every page
+11  Chunked pre-calculation via $reloadState flag (2.1)       medium   ~20N queries -> ~2N + 10/chunk
+12  unique('dominion_id') on dominion_tick (4.3)              medium*  correctness + faster join
+
+ * Requires verifying no duplicates exist in production before the constraint
+   will apply.
+
+Items 1-9 are individually small and independently shippable. Items 10 and 11
+are the structural ones and are where the bulk of the time actually is - I'd
+want item 2's measurements in hand before committing to either.
+
+
+================================================================================
+CAVEAT
+================================================================================
+
+Every number above is derived by reading code, not by profiling. The call-graph
+fan-out and query counts are arithmetic and I'm confident in them; how they
+translate to wall-clock depends on database latency, connection locality, and
+actual N - which cannot be seen from a static read. Item 2 exists to close that
+gap.
+
+No changes were made to the repository as part of this review.

--- a/phase0_headline.md
+++ b/phase0_headline.md
@@ -1,0 +1,54 @@
+# Tick Benchmark — Phase 0 Headline Numbers
+
+Baseline measurement of `TickService` before any optimization work.
+
+- **Date:** 2026-08-12
+- **Commit:** `d287fd7a1` (branch `feature/tick-performance`)
+- **Harness:** `tests/Benchmark/TickBaselineReportTest.php`, run with `./vendor/bin/phpunit --group=benchmark`
+- **Environment:** Docker (`php:8.5-apache`, PHP 8.5.9, MariaDB 10.11), PHPUnit 12.5.24
+
+## Headline
+
+| Measurement | Queries | Wall time | Share in PHP |
+|---|---|---|---|
+| `precalculateTick()`, one dominion | **19** | 38.9 ms | 80% |
+| `performTick($round, $dominion)`, single-dominion path | **77** | 129.5 ms | 76% |
+| `performTick($round)`, N = 10 | **611** (61.10/dom) | 994.5 ms | 75% |
+| `performTick($round)`, N = 40 | **2358** (58.95/dom) | 3973.8 ms | 74% |
+
+## Scaling (N = 10 → 40)
+
+| | |
+|---|---|
+| Marginal cost | **58.23 queries per additional dominion** |
+| Fixed overhead | 28.7 queries per round |
+| Wall time growth | 4.00× for 4.00× the dominions |
+
+Linear at this scale — Phase A's bulk update is constant regardless of N. The
+cost is a large per-dominion constant, not bad scaling.
+
+Extrapolating the same shape to N = 1500: roughly 87,000 queries and ~150 s.
+
+## Most repeated statements (N = 40)
+
+| Executions | Per dominion | Statement |
+|---|---|---|
+| 240× | 6 | `spell_perk_types` pivot select (also slowest by total time, 85.2 ms) |
+| 120× | 3 | `select * from dominions where id = ? limit 1` |
+| 120× | 3 | `select * from spells where id = ? limit 1` |
+| 84× | ~2 | `unit_perk_types` pivot select |
+| 80× | 2 | `select * from dominion_tick where dominion_id = ? limit 1` |
+| 80× | 2 | `select spell_id from dominion_spells where dominion_id = ? and duration <= ?` |
+
+## Caveats
+
+- Query counts are deterministic and machine-independent; **wall times are not**
+  and must never be asserted on.
+- Tests run under `DatabaseTransactions`, so the tick's own `DB::transaction`
+  calls degrade to savepoints. Commit cost and lock contention are **not**
+  measured — finding 5.2 needs a real-scale profile run.
+- Reference-data caches (`Race::findWithRelationsCached`, `Round::findCached`)
+  are warmed before measurement, hiding roughly one query per distinct race plus
+  one per round. That is fixed cost, not per-dominion cost.
+- N = 10/40 against a production N in the thousands. Linearity is established by
+  the slope between the two, not by absolute magnitude.

--- a/phase0_headline.md
+++ b/phase0_headline.md
@@ -12,9 +12,18 @@ Baseline measurement of `TickService` before any optimization work.
 | Measurement | Queries | Wall time | Share in PHP |
 |---|---|---|---|
 | `precalculateTick()`, one dominion | **19** | 38.9 ms | 80% |
-| `performTick($round, $dominion)`, single-dominion path | **77** | 129.5 ms | 76% |
+| `performTick($round, $dominion)`, single-dominion path | **77** [^1] | 129.5 ms | 76% |
 | `performTick($round)`, N = 10 | **611** (61.10/dom) | 994.5 ms | 75% |
 | `performTick($round)`, N = 40 | **2358** (58.95/dom) | 3973.8 ms | 74% |
+
+[^1]: This figure is measurement-order dependent, and phase 1 measures **91**
+    for the same call. The single-dominion branch skips the eager-load at
+    `TickService.php:395-409`, so it inherits whatever relation state the
+    caller's model carries; `precalculateTick`'s `loadMissing()` for the race
+    relations then costs 0 or 14 queries accordingly. The run above profiled
+    `precalculateTick` on the same instance immediately beforehand, leaving them
+    warm. `TickBenchmarkBudgets::SINGLE_DOMINION_TICK_MAX_QUERIES` holds the cold
+    number, 91, as the worst case.
 
 ## Scaling (N = 10 → 40)
 

--- a/phase0_headline.md
+++ b/phase0_headline.md
@@ -1,5 +1,25 @@
 # Tick Benchmark — Phase 0 Headline Numbers
 
+> **⚠ SUPERSEDED — the per-dominion figures below are inflated by roughly 2x.**
+>
+> These were measured against a skewed fixture. `BenchmarkRoundSeeder` picked the
+> spells carrying the most perks, and `death_and_decay` — which holds
+> `convert_peasants_to_self_military_unit1` — is among them. That put a
+> `performSpellEffects` special case on **every** dominion, so every dominion
+> took a `Dominion::update()`, fired `DominionSaved`, and paid for a second
+> `precalculateTick`.
+>
+> Corrected in phase 2. Per-dominion cost is **31.57**, not 58.95; marginal cost
+> is **30.90**, not 58.23. See `TickBenchmarkBudgets` for the current numbers.
+>
+> Two conclusions below are wrong as written: the claim that `precalculateTick`
+> runs 2–3x for *every* dominion (it runs once per dominion plus once per
+> dominion carrying one of three special spells — 44 calls for 40 dominions), and
+> the ~87,000 query / ~150 s extrapolation to N=1500, which halves.
+>
+> What still holds: the 19-query `precalculateTick` figure, the 74–76% PHP share,
+> the linear scaling, and every N+1 identified.
+
 Baseline measurement of `TickService` before any optimization work.
 
 - **Date:** 2026-08-12

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -15,7 +15,20 @@
     <testsuite name="Unit">
       <directory suffix="Test.php">./tests/Unit</directory>
     </testsuite>
+    <testsuite name="Benchmark">
+      <directory suffix="Test.php">./tests/Benchmark</directory>
+    </testsuite>
   </testsuites>
+  <!--
+    Benchmarks seed tens of dominions and tick them; they are far too slow for
+    the default run. Excluded here, opted into with `--group=benchmark`, which
+    overrides this exclusion.
+  -->
+  <groups>
+    <exclude>
+      <group>benchmark</group>
+    </exclude>
+  </groups>
   <php>
     <env name="APP_ENV" value="testing"/>
     <env name="BCRYPT_ROUNDS" value="4"/>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -21,8 +21,8 @@
   </testsuites>
   <!--
     Benchmarks seed tens of dominions and tick them; they are far too slow for
-    the default run. Excluded here, opted into with `--group=benchmark`, which
-    overrides this exclusion.
+    the default run. Excluded here, and opted into by passing the group on the
+    command line, which overrides this exclusion.
   -->
   <groups>
     <exclude>

--- a/secondroundfindings.txt
+++ b/secondroundfindings.txt
@@ -1,0 +1,285 @@
+================================================================================
+OpenDominion Hourly Tick - Performance Review (Second Round)
+================================================================================
+
+Scope:  game:tick -> TickService::tickHourly() and everything it reaches.
+Method: Static analysis - no .env is present in this checkout, so no live
+        profiling was possible. Unlike the first-round (codex) report, this
+        review also verified its claims against git history and checked the
+        tick-adjacent services it skipped (hero battles, raids, valuables,
+        notifications).
+
+HEADLINE
+    The codex report is accurate and well-targeted. All 19 of its findings
+    were re-traced against the current source and ALL of them hold up - the
+    line numbers, query counts, and call-graph arithmetic are correct. This
+    review found ONE factual error in a mechanism (which doesn't change the
+    conclusion), RESOLVED one of its open caveats with git evidence, and
+    identified FOUR meaningful findings it missed, one of which is arguably
+    a top-tier item.
+
+
+================================================================================
+PART 1 - VERIFICATION OF THE CODEX FINDINGS
+================================================================================
+
+Each claim was re-traced in the source:
+
+ Codex finding                                     Verdict
+ ------------------------------------------------- ----------------------------
+ 2.1 precalculateTick() ~20 queries/dominion,      CONFIRMED. The load() at
+     discards the eager-load                       TickService.php:1022
+                                                   re-queries 10 relations per
+                                                   dominion; realm wonders
+                                                   re-fetched per dominion, not
+                                                   per realm. Query tally of
+                                                   ~19-20 is right.
+ 2.2 Per-dominion cleanup + nested spell N+1       CONFIRMED
+                                                   (TickService.php:899-959;
+                                                   lazy $dominionSpell->spell
+                                                   at line 906).
+ 2.3 Unmemoized perk rebuilds on Dominion          CONFIRMED
+                                                   (Dominion.php:731-833).
+                                                   resolveSpellPerk()
+                                                   (SpellCalculator.php:254)
+                                                   does 5-6 full rebuilds per
+                                                   lookup; ProductionCalculator
+                                                   alone has 10 resolveSpellPerk
+                                                   call sites. All calculators
+                                                   are container singletons
+                                                   (AppServiceProvider.php:
+                                                   129-154), so the proposed
+                                                   memoization has well-defined
+                                                   invalidation points.
+ 2.4 Population calculator fan-out                 CONFIRMED
+     (~10x getPopulationMilitary, ~4 collection    (PopulationCalculator.php:
+     allocations per queue scan)                   350-360,
+                                                   QueueService.php:47-57).
+ 3.1 Discarded getActiveSpells() call              CONFIRMED, and its caveat is
+                                                   now resolved - see below.
+ 3.2 Valuable count per dominion                   CONFIRMED
+                                                   (MilitaryCalculator.php:
+                                                   1016-1019).
+ 3.3 User-agent parsing per dominion               CONCLUSION CONFIRMED,
+                                                   MECHANISM WRONG - see below.
+ 3.4 DominionSaved double-precalculation           CONFIRMED
+                                                   (Listeners/DominionSaved.php
+                                                   :52 runs a full networth
+                                                   calc + precalculateTick on
+                                                   every update() inside
+                                                   performSpellEffects, then
+                                                   the main loop precalculates
+                                                   again).
+ 3.5 N+1s in performSpellEffects                   CONFIRMED (lazy ->dominion,
+                                                   ->spell->perks() at lines
+                                                   789, 815, 832; plus the
+                                                   guard SELECT in
+                                                   Dominion::save() at
+                                                   Dominion.php:454-459).
+ 3.6-3.9 (log hydration, dead eager loads,         ALL CONFIRMED. One nuance:
+     N transactions)                               the second
+                                                   $round->activeDominions
+                                                   ->count() (line 438) reuses
+                                                   the cached relation, so the
+                                                   hydration cost is paid once,
+                                                   not twice - still a
+                                                   full-round hydration purely
+                                                   to log a number.
+ 4.1-4.3 (quadratic rankings self-join,            ALL CONFIRMED. daily_rankings
+     unbounded upsert, missing unique on           carries only
+     dominion_tick.dominion_id)                    unique(dominion_id, key);
+                                                   dominion_tick has only an FK
+                                                   on dominion_id, no unique
+                                                   index.
+ 5.1-5.3 (no withoutOverlapping, long              ALL CONFIRMED
+     transactions, two-datapoint                   (Console/Kernel.php:18).
+     instrumentation)
+
+--------------------------------------------------------------------------------
+Correction to codex 3.3 (user-agent parsing)
+--------------------------------------------------------------------------------
+
+Codex claims that in console request()->userAgent() is NULL and that's why the
+'Symfony/3.X' early-out doesn't fire. That's wrong: Laravel's
+SetRequestForConsole bootstrapper builds the console request via
+Request::create(), which injects Symfony's default HTTP_USER_AGENT - which has
+been 'Symfony' (no version suffix) since Symfony 4. So the UA is the string
+'Symfony', not null. The guard at ActivityService.php:44 compares against the
+Symfony 3-era default and silently broke when the framework was upgraded.
+
+The conclusion is identical - jenssegers/agent runs its full Mobile_Detect
+regex battery once per dominion per tick for nothing - but the correct fix is
+app()->runningInConsole() (or matching the current default), and it's worth
+knowing the guard is bit-rotted rather than merely too narrow.
+
+--------------------------------------------------------------------------------
+Codex 3.1's open caveat, resolved
+--------------------------------------------------------------------------------
+
+Codex recommended deleting the discarded
+$this->spellCalculator->getActiveSpells($dominion); at line 1040 but hedged:
+"worth confirming against git log that it wasn't a deliberate cache-warm."
+
+That check was done. Commit 78339a87c ("remove spell caching", April 2021)
+changed the call from getActiveSpells($dominion, true) - where true was a
+cache-refresh flag - to the current form when the caching layer was deleted
+from SpellCalculator. It WAS a cache-warm, and it has been a pure no-op
+(~3 wasted queries x N) for four years. Safe to delete.
+
+
+================================================================================
+PART 2 - FINDINGS THE CODEX REPORT MISSED
+================================================================================
+
+--------------------------------------------------------------------------------
+M1. Phase B runs the full per-dominion pass on dominions still in protection
+    (the biggest miss)
+--------------------------------------------------------------------------------
+
+Phase A ticks only dominions matching protection_finished = true
+(TickService.php:275). But Phase B iterates $round->activeDominions()
+(line 395), which is defined as dominions()->where('locked_at', null)
+(Round.php:80-83) - it includes EVERY dominion still in protection. Each of
+those pays the entire per-dominion cost every hour - transaction, spell/queue
+cleanup, and the ~20-query precalculateTick - even though Phase A changed
+nothing about them.
+
+Protection dominions already maintain their own tick state: the manual
+advance-tick path (MiscController.php:404, AutomationService.php:174) calls
+performTick($round, $dominion) directly, and every action they take fires the
+DominionSaved listener which re-precalculates. In the opening days of a round,
+dominions in protection are a large fraction of N, so filtering Phase B to
+protection_finished = true removes a large slice of the loop precisely when
+the game is busiest.
+
+One caveat to verify before doing it: the hourly re-precalc is currently what
+refreshes a protection dominion's predicted tick after EXTERNAL realm-wide
+changes (a wonder being built or destroyed mid-protection). That's a narrow
+edge case - the stale prediction would self-correct on their next action -
+but it's a game-rules call, not a pure refactor.
+
+--------------------------------------------------------------------------------
+M2. precalculateTick computes every production value twice
+--------------------------------------------------------------------------------
+
+Lines 1070-1087 call getLumberProduction() and getLumberDecay(), then
+getLumberNetChange() - which recomputes both (ProductionCalculator.php:
+464-467). The same pattern repeats for mana (line 595) and food
+(getFoodNetChange at line 339 recomputes production AND consumption AND
+decay). And getBoatProduction($dominion) is simply called twice verbatim on
+consecutive lines 1080-1081.
+
+This matters because each of these walks the full raw x multiplier chain -
+race perks, tech perks, wonder perks, and resolveSpellPerk (5-6 unmemoized
+perk-collection rebuilds each). The production portion of pre-calculation
+costs roughly 2x what it should, per dominion, per tick. Hoisting each value
+into a local is a ~15-line, zero-risk change that is independent of (and
+multiplicative with) codex's memoization item 2.3. Note the food consumption
+path also re-enters the population calculator, so this compounds codex's 2.4
+as well.
+
+--------------------------------------------------------------------------------
+M3. performRaceUnitProduction pays the expensive check first, for every
+    dominion
+--------------------------------------------------------------------------------
+
+At TickService.php:855, the loop calls
+resolveSpellPerk($dominion, 'disable_unit_summoning') - 5-6 full spell-perk
+rebuilds - BEFORE checking whether the dominion's race has any summons_unit
+unit. Exactly one race in the game data has that perk
+(app/data/races/planewalker.yml). Reordering the guard (check the race's
+units first - cheap, since races are cached via
+Race::findWithRelationsCached) makes this near-free for ~everyone, and the
+surrounding round-wide transaction (codex 5.2) then holds locks for almost no
+time.
+
+--------------------------------------------------------------------------------
+M4. Two more per-dominion queries are derivable from already-loaded data
+--------------------------------------------------------------------------------
+
+Codex counted the incoming-queue SELECT (line 1043, hours = 1) and the
+expiring-spells SELECT (line 1147, duration <= 1) in its ~20-query tally but
+treated them as inherent. They aren't: twenty lines earlier, precalculateTick
+loads $dominion->queues and $dominion->spells (with pivot durations) - both
+result sets are already in memory and just need a collection filter. That's
+-2N queries with no schema work, on top of codex 2.1's chunked re-hydration.
+
+--------------------------------------------------------------------------------
+Smaller observations codex didn't cover
+--------------------------------------------------------------------------------
+
+- Notification inserts are row-at-a-time. sendNotifications
+  (NotificationService.php:51) writes one synchronous notifications INSERT per
+  notification type per player dominion via the database channel, plus
+  per-type settings lookups. It correctly early-outs for NPDs (~80% of
+  dominions), which caps the damage; batching the web-notification inserts is
+  possible but low-yield. The hourly email digest is properly queued
+  (ShouldQueue), so that's fine.
+
+- ValuablesService::processValuables (line 155) updates rows one save() at a
+  time inside ->each(); both passes apply uniform transitions and could be
+  two bulk UPDATEs. Small volumes, small win.
+
+- NPD-generation hour: each spawned NPD gets an individual performTick()
+  (line 242), which re-runs performSpellEffects' three SpellPerkType/Spell
+  lookups and the full single-dominion flow per NPD. It's a once-per-round
+  event, but the hour it fires is already the round's heaviest.
+
+- Phase-A consistency note (not perf): the spell and queue decrement UPDATEs
+  (lines 365-380) don't carry the abandoned_at exclusion that the dominions
+  UPDATE has - abandoned dominions' queues and spells keep ticking down while
+  their resources don't. It looks intended (they still get Phase-B cleanup),
+  but it's the kind of asymmetry worth a deliberate comment.
+
+- Hero battles / raids / tournaments (HeroBattleService::processBattles,
+  RaidService::processCompletedRaids) are per-row but low-volume and
+  event-driven; nothing worth changing there now.
+
+
+================================================================================
+PART 3 - MERGED PRIORITY ORDER
+================================================================================
+
+Codex's sequencing is sound; the new additions slot in as follows (its
+numbering kept, new items prefixed M):
+
+  1. withoutOverlapping() on game:tick (5.1) - correctness insurance, zero
+     risk.
+  2. Per-phase timing + query counts (5.3) - converts every estimate below
+     into a measurement.
+  3. Zero-risk deletions: dead getActiveSpells() (3.1, now git-verified),
+     dead eager loads (3.7/3.8), console guard fix (3.3, corrected
+     mechanism), log-count hydration (3.6).
+  4. M2 - hoist double production computation - ~15 lines, zero risk, halves
+     production CPU.
+  5. M3 - reorder the summons_unit guard - a few lines, zero risk.
+  6. Hoist repeats in getPopulationPeasantGrowth (2.4) + M4 in-memory
+     queue/spell filters.
+  7. Batch cleanup (2.2), with() + withoutEvents in performSpellEffects
+     (3.4/3.5).
+  8. M1 - exclude protection dominions from Phase B - big win early-round,
+     needs the wonder-staleness game-rules check first.
+  9. Window-function rankings + index (4.1), chunked upserts (4.2).
+ 10. Perk memoization (2.3) and chunked pre-calculation (2.1) - the
+     structural items; do these with item 2's measurements in hand.
+ 11. unique('dominion_id') on dominion_tick (4.3) after verifying production
+     has no duplicates.
+
+
+================================================================================
+COMPARATIVE ASSESSMENT
+================================================================================
+
+The codex report is genuinely good: its two structural diagnoses
+(per-dominion query storm in precalculateTick, unmemoized perk rebuilds) are
+the correct center of gravity, and no false positives were found in it. Its
+weaknesses were at the edges: it treated the Phase-B POPULATION as a given
+and never questioned who is in the loop (M1), stopped at the query layer
+inside precalculateTick without noticing the duplicated compute between
+adjacent lines (M2, M3), one bit-rotted mechanism it explained incorrectly
+(3.3), and one caveat it left open that ten seconds of `git log -S` closes
+(3.1). Both reports share the same honest limitation: every number is
+call-graph arithmetic, not a profile - its own item 5.3 (instrumentation
+first) remains the right first move.
+
+No changes were made to the repository as part of this review.

--- a/src/Calculators/Dominion/PopulationCalculator.php
+++ b/src/Calculators/Dominion/PopulationCalculator.php
@@ -349,12 +349,17 @@ class PopulationCalculator
      */
     public function getPopulationPeasantGrowth(Dominion $dominion): int
     {
-        $maximumPeasantDeath = round(-0.05 * $dominion->peasants - $this->getPopulationDrafteeGrowth($dominion));
+        // Hoisted: each call walks getPopulationMilitary twice, and that scans
+        // the dominion's whole queue collection five times over. Three calls
+        // here cost roughly thirty queue scans; one costs ten.
+        $drafteeGrowth = $this->getPopulationDrafteeGrowth($dominion);
+
+        $maximumPeasantDeath = round(-0.05 * $dominion->peasants - $drafteeGrowth);
         if ($maximumPeasantDeath > -50) {
             $maximumPeasantDeath = max(-50, -$dominion->peasants);
         }
-        $roomForPeasants = ($this->getMaxPopulation($dominion) - $this->getPopulation($dominion) - $this->getPopulationDrafteeGrowth($dominion));
-        $currentPopulationChange = ($this->getPopulationBirth($dominion) - $this->getPopulationDrafteeGrowth($dominion));
+        $roomForPeasants = ($this->getMaxPopulation($dominion) - $this->getPopulation($dominion) - $drafteeGrowth);
+        $currentPopulationChange = ($this->getPopulationBirth($dominion) - $drafteeGrowth);
 
         $maximumPopulationChange = min($roomForPeasants, $currentPopulationChange);
         return max($maximumPeasantDeath, $maximumPopulationChange);

--- a/src/Calculators/ValorCalculator.php
+++ b/src/Calculators/ValorCalculator.php
@@ -17,6 +17,17 @@ class ValorCalculator
     protected const FIXED_VALOR_LAND_CONQUERED = 1500;
     protected const FIXED_VALOR_BOUNTIES = 1500;
 
+    /**
+     * The only ranking keys fixed valor reads.
+     *
+     * @var array<int, string>
+     */
+    protected const FIXED_VALOR_KEYS = [
+        'largest-dominions',
+        'total-land-conquered',
+        'bounties-collected',
+    ];
+
     /** @var LandCalculator */
     protected $landCalculator;
 
@@ -136,13 +147,38 @@ class ValorCalculator
 
     public function calculateFixedValor(Round $round, Collection $dominions)
     {
+        // Totals span the whole round, so they are aggregated in SQL rather
+        // than summed over a hydrated collection of every ranking row.
+        $totals = DailyRanking::query()
+            ->where('round_id', $round->id)
+            ->where('realm_number', '!=', 0)
+            ->whereIn('key', self::FIXED_VALOR_KEYS)
+            ->selectRaw('`key`, SUM(`value`) as total')
+            ->groupBy('key')
+            ->pluck('total', 'key');
+
+        $totalLand = (int)$totals->get('largest-dominions', 0);
+        $totalLandConquered = (int)$totals->get('total-land-conquered', 0);
+        $totalBounties = (int)$totals->get('bounties-collected', 0);
+
+        // The realm_number filter here is deliberate and differs from
+        // calculateBreakdown(), which fetches its per-dominion rows unfiltered.
+        // A dominion whose rows were recorded in realm 0 has always scored
+        // nothing for land rank, land conquered and bounties. Do not "align"
+        // the two methods - ValorCalculatorTest pins this.
+        //
+        // Indexed once by dominion and key, instead of re-filtering the whole
+        // collection inside the loop below.
         $rankings = DailyRanking::query()
             ->where('round_id', $round->id)
             ->where('realm_number', '!=', 0)
-            ->get();
-        $totalLand = $rankings->where('key', 'largest-dominions')->sum('value');
-        $totalLandConquered = $rankings->where('key', 'total-land-conquered')->sum('value');
-        $totalBounties = $rankings->where('key', 'bounties-collected')->sum('value');
+            ->whereIn('dominion_id', $dominions->pluck('id'))
+            ->whereIn('key', self::FIXED_VALOR_KEYS)
+            ->get(['dominion_id', 'key', 'rank', 'value'])
+            ->groupBy('dominion_id')
+            ->map(static function ($rows) {
+                return $rows->keyBy('key');
+            });
 
         $fixedValor = [];
         foreach ($dominions as $dominion) {
@@ -150,10 +186,12 @@ class ValorCalculator
                 $fixedValor[$dominion->id] = 0;
             }
             $totalValor = 0;
-            $domRankings = $rankings->where('dominion_id', $dominion->id);
-            $landRank = $domRankings->where('key', 'largest-dominions')->pluck('rank')->first() ?? 0;
-            $landConquered = $domRankings->where('key', 'total-land-conquered')->pluck('value')->first() ?? 0;
-            $bounties = $domRankings->where('key', 'bounties-collected')->pluck('value')->first() ?? 0;
+            $domRankings = $rankings->get($dominion->id);
+            // ?? 0 covers both a missing row and a NULL rank, which is what the
+            // previous ->pluck('rank')->first() ?? 0 did.
+            $landRank = $domRankings?->get('largest-dominions')?->rank ?? 0;
+            $landConquered = $domRankings?->get('total-land-conquered')?->value ?? 0;
+            $bounties = $domRankings?->get('bounties-collected')?->value ?? 0;
 
             $totalValor += $this->getFixedValorLandRank($landRank);
             // TODO: Pass in land total instead?
@@ -217,12 +255,18 @@ class ValorCalculator
 
     public function calculateBonusValor(Round $round, Collection $dominions)
     {
-        $valor = Valor::where('round_id', $round->id)->get();
+        // Summed per dominion in SQL rather than by re-filtering a collection
+        // of the round's entire valor history once per dominion.
+        $totals = Valor::query()
+            ->where('round_id', $round->id)
+            ->whereIn('dominion_id', $dominions->pluck('id'))
+            ->selectRaw('dominion_id, SUM(amount) as total')
+            ->groupBy('dominion_id')
+            ->pluck('total', 'dominion_id');
 
         $bonusValor = [];
         foreach ($dominions as $dominion) {
-            $individualValor = $valor->where('dominion_id', $dominion->id)->sum('amount');
-            $bonusValor[$dominion->id] = $individualValor;
+            $bonusValor[$dominion->id] = (float)$totals->get($dominion->id, 0);
         }
 
         return $bonusValor;

--- a/src/Console/Commands/Development/RealmSeederCommand.php
+++ b/src/Console/Commands/Development/RealmSeederCommand.php
@@ -3,6 +3,7 @@
 namespace OpenDominion\Console\Commands\Development;
 
 use Illuminate\Console\Command;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
 use OpenDominion\Console\Commands\CommandInterface;
@@ -43,7 +44,7 @@ class RealmSeederCommand extends Command implements CommandInterface
             DB::transaction(function () use ($count, $dominionFactory, $round) {
                 $realms = Realm::active()->where('round_id', '=', $round->id)->get();
                 foreach($realms as $realm) {
-                    $races = Race::get(['id'])->toArray();
+                    $races = $this->racesForRealm($round, $realm);
                     $dom_count = Dominion::where('realm_id', $realm->id)->count();
                     $user = User::factory()->count(8 - $dom_count)->create()->each(function ($user) use ($dominionFactory, $realm, $races) {
                         $randomString = Str::random(10);
@@ -51,7 +52,7 @@ class RealmSeederCommand extends Command implements CommandInterface
                         $dominionFactory->create(
                             $user,
                             $realm,
-                            Race::findOrFail($races[array_rand($races)]['id']),
+                            $races->random(),
                             "Ruler $randomString",
                             "Dominion $randomString",
                         );
@@ -61,14 +62,14 @@ class RealmSeederCommand extends Command implements CommandInterface
                 for ($n = count($realms)+1; $n <= $count; $n++) {
                     $alignment = rand(0, 1) ? 'good' : 'evil';
                     $realm = app(RealmFactory::class)->create($round, $alignment);
-                    $races = Race::get(['id'])->toArray();
+                    $races = $this->racesForRealm($round, $realm);
                     $user = User::factory()->count(8)->create()->each(function ($user) use ($dominionFactory, $realm, $races) {
                         $randomString = Str::random(10);
 
                         $dominionFactory->create(
                             $user,
                             $realm,
-                            Race::findOrFail($races[array_rand($races)]['id']),
+                            $races->random(),
                             "Ruler $randomString",
                             "Dominion $randomString",
                         );
@@ -78,5 +79,31 @@ class RealmSeederCommand extends Command implements CommandInterface
         } else {
             throw new RuntimeException('No rounds found, seed the development database first.');
         }
+    }
+
+    /**
+     * Returns the races that may legally be placed in a realm.
+     *
+     * DominionFactory rejects a race whose alignment differs from the realm's
+     * unless the round is mixed alignment, so picking from all races at random
+     * fails as soon as the coin lands the wrong way.
+     *
+     * @return \Illuminate\Support\Collection<int, Race>
+     */
+    private function racesForRealm(Round $round, Realm $realm): Collection
+    {
+        $races = Race::where('playable', true)
+            ->when(!$round->mixed_alignment, static function ($query) use ($realm) {
+                return $query->where('alignment', $realm->alignment);
+            })
+            ->get();
+
+        if ($races->isEmpty()) {
+            throw new RuntimeException(
+                "No playable races found for realm {$realm->number} ({$realm->alignment})."
+            );
+        }
+
+        return $races;
     }
 }

--- a/src/Console/Commands/Development/TickProfileCommand.php
+++ b/src/Console/Commands/Development/TickProfileCommand.php
@@ -1,0 +1,323 @@
+<?php
+
+namespace OpenDominion\Console\Commands\Development;
+
+use DB;
+use Illuminate\Console\Command;
+use OpenDominion\Console\Commands\CommandInterface;
+use OpenDominion\Models\Round;
+use OpenDominion\Services\Dominion\TickService;
+use OpenDominion\Services\QueryProfilerService;
+use RuntimeException;
+use Throwable;
+
+/**
+ * Profiles a real tick at production scale.
+ *
+ * The PHPUnit benchmarks in tests/Benchmark cap out around 40 dominions and run
+ * inside a wrapping transaction, which turns the tick's own DB::transaction
+ * calls into savepoints. That hides two things the findings reports care about:
+ *
+ *   - Finding 4.1, the quadratic daily-rankings self-join. Its cost lives inside
+ *     one statement and is invisible below roughly a thousand dominions.
+ *   - Finding 5.2, long transactions locking out live players. Commit cost and
+ *     lock contention are not measured at all when everything is a savepoint.
+ *
+ * This command exists to close that gap. Point it at a database seeded with
+ * dev:seed:realms and it reports the same shape of numbers as the benchmark
+ * suite, at whatever N you actually have.
+ */
+class TickProfileCommand extends Command implements CommandInterface
+{
+    /** @var string The name and signature of the console command. */
+    protected $signature = 'dev:tick:profile
+                             {--round= : Round id to profile. Defaults to the most recent active round.}
+                             {--commit : Keep the tick. By default everything is rolled back.}
+                             {--rankings : Also profile updateDailyRankings(), which is where finding 4.1 lives.}
+                             {--limit=15 : How many repeated statements to list.}';
+
+    /** @var string The console command description. */
+    protected $description = 'Profiles a real tick at production scale and reports query counts and timings.';
+
+    public function __construct(
+        private readonly QueryProfilerService $profiler,
+        private readonly TickService $tickService,
+    ) {
+        parent::__construct();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function handle(): void
+    {
+        if (app()->environment('production')) {
+            throw new RuntimeException('dev:tick:profile must never be run against production.');
+        }
+
+        $round = $this->resolveRound();
+        $dominionCount = $round->activeDominions()->count();
+
+        if ($dominionCount === 0) {
+            throw new RuntimeException("Round {$round->id} has no active dominions. Seed it with dev:seed:realms first.");
+        }
+
+        $commit = (bool)$this->option('commit');
+
+        $this->line('');
+        $this->info(sprintf('Profiling round %d (%s)', $round->id, $round->name));
+        $this->line(sprintf('  active dominions   %s', number_format($dominionCount)));
+        $this->line(sprintf('  mode               %s', $commit ? 'COMMIT - the tick will be kept' : 'rollback - nothing is kept'));
+        $this->line('');
+
+        if ($commit && !$this->confirmCommit($round, $dominionCount)) {
+            $this->warn('Aborted.');
+            return;
+        }
+
+        $this->warmUp($round);
+
+        if ($commit) {
+            $this->profileTick($round, $dominionCount);
+        } else {
+            $this->withRollback(function () use ($round, $dominionCount): void {
+                $this->profileTick($round, $dominionCount);
+            });
+        }
+
+        if ($this->option('rankings')) {
+            $this->profileRankings($commit);
+        }
+    }
+
+    private function resolveRound(): Round
+    {
+        $roundId = $this->option('round');
+
+        if ($roundId !== null) {
+            $round = Round::find((int)$roundId);
+
+            if ($round === null) {
+                throw new RuntimeException("No round with id {$roundId}.");
+            }
+
+            return $round;
+        }
+
+        $round = Round::active()->orderByDesc('start_date')->first();
+
+        if ($round === null) {
+            throw new RuntimeException('No active round found. Pass --round= explicitly.');
+        }
+
+        return $round;
+    }
+
+    /**
+     * Committing a tick advances real game state and cannot be undone, so it
+     * takes an explicit confirmation naming what is about to change.
+     */
+    private function confirmCommit(Round $round, int $dominionCount): bool
+    {
+        $this->warn(sprintf(
+            'This will TICK %s dominions in round %d for real. Resources, queues, spells and',
+            number_format($dominionCount),
+            $round->id
+        ));
+        $this->warn('history will all advance by an hour, and it cannot be undone.');
+        $this->line('');
+
+        return $this->confirm('Continue?', false);
+    }
+
+    /**
+     * Runs the profile inside a transaction that is always rolled back.
+     *
+     * This is the default because pointing a profiler at a dev database should
+     * not silently consume a game hour. The tradeoff is the same one the PHPUnit
+     * benchmarks make: the tick's inner transactions become savepoints, so commit
+     * cost is not measured. Use --commit when that is what you are after.
+     */
+    private function withRollback(callable $callback): void
+    {
+        DB::beginTransaction();
+
+        try {
+            $callback();
+        } finally {
+            DB::rollBack();
+            $this->line('  (rolled back)');
+            $this->line('');
+        }
+    }
+
+    /**
+     * Excludes one-off cache population from the measurement, matching what
+     * AbstractTickBenchmarkTestCase does, so the numbers stay comparable.
+     */
+    private function warmUp(Round $round): void
+    {
+        $this->profiler->withoutRecording(function () use ($round): void {
+            $dominion = $round->activeDominions()->with('race')->first();
+
+            if ($dominion !== null) {
+                $this->tickService->precalculateTick($dominion);
+            }
+        });
+    }
+
+    private function profileTick(Round $round, int $dominionCount): void
+    {
+        $this->profiler->start();
+        $startedAt = hrtime(true);
+
+        try {
+            $this->tickService->performTick($round);
+        } catch (Throwable $e) {
+            $this->profiler->stop();
+            throw $e;
+        }
+
+        $wallMs = (hrtime(true) - $startedAt) / 1000000;
+        $queries = $this->profiler->stop();
+
+        $this->report('performTick()', $queries, $wallMs, $dominionCount);
+    }
+
+    private function profileRankings(bool $commit): void
+    {
+        $run = function (): array {
+            $this->profiler->start();
+            $startedAt = hrtime(true);
+
+            try {
+                $this->tickService->updateDailyRankings();
+            } catch (Throwable $e) {
+                $this->profiler->stop();
+                throw $e;
+            }
+
+            return [$this->profiler->stop(), (hrtime(true) - $startedAt) / 1000000];
+        };
+
+        if ($commit) {
+            [$queries, $wallMs] = $run();
+        } else {
+            DB::beginTransaction();
+
+            try {
+                [$queries, $wallMs] = $run();
+            } finally {
+                DB::rollBack();
+            }
+        }
+
+        $this->report('updateDailyRankings()', $queries, $wallMs, null);
+
+        $this->line('  Finding 4.1 lives in the daily_rankings self-join above. If one statement');
+        $this->line('  dominates the timing, that is the unindexed range self-join.');
+        $this->line('');
+    }
+
+    /**
+     * @param array<int, array{sql: string, bindings: array, time: float}> $queries
+     */
+    private function report(string $label, array $queries, float $wallMs, ?int $dominionCount): void
+    {
+        $queryMs = array_sum(array_column($queries, 'time'));
+        $count = count($queries);
+
+        $this->line('');
+        $this->info($label);
+        $this->line(str_repeat('-', 72));
+
+        $rows = [
+            ['queries', number_format($count)],
+            ['wall time', sprintf('%s ms', number_format($wallMs, 1))],
+            ['in database', sprintf('%s ms (%s%%)', number_format($queryMs, 1), $this->percentage($queryMs, $wallMs))],
+            ['in php', sprintf('%s ms (%s%%)', number_format(max(0, $wallMs - $queryMs), 1), $this->percentage($wallMs - $queryMs, $wallMs))],
+            ['peak memory', sprintf('%s MB', number_format(memory_get_peak_usage(true) / 1048576, 1))],
+        ];
+
+        if ($dominionCount !== null && $dominionCount > 0) {
+            $rows[] = ['queries per dominion', number_format($count / $dominionCount, 2)];
+            $rows[] = ['wall time per dominion', sprintf('%s ms', number_format($wallMs / $dominionCount, 2))];
+        }
+
+        $this->table(['metric', 'value'], $rows);
+
+        $this->renderByTable($queries, $dominionCount);
+        $this->renderRepeats($queries, $dominionCount);
+    }
+
+    /**
+     * @param array<int, array{sql: string, bindings: array, time: float}> $queries
+     */
+    private function renderByTable(array $queries, ?int $dominionCount): void
+    {
+        $counts = [];
+
+        foreach ($queries as $query) {
+            $table = QueryProfilerService::primaryTable($query['sql']) ?? '(unknown)';
+            $counts[$table] = ($counts[$table] ?? 0) + 1;
+        }
+
+        arsort($counts);
+
+        $rows = [];
+
+        foreach (array_slice($counts, 0, 15, true) as $table => $count) {
+            $rows[] = [
+                $table,
+                number_format($count),
+                $dominionCount ? number_format($count / $dominionCount, 2) : '-',
+            ];
+        }
+
+        $this->table(['table', 'queries', 'per dominion'], $rows);
+    }
+
+    /**
+     * @param array<int, array{sql: string, bindings: array, time: float}> $queries
+     */
+    private function renderRepeats(array $queries, ?int $dominionCount): void
+    {
+        $groups = [];
+
+        foreach ($queries as $query) {
+            $normalized = QueryProfilerService::normalize($query['sql']);
+
+            if (!isset($groups[$normalized])) {
+                $groups[$normalized] = ['count' => 0, 'totalMs' => 0.0];
+            }
+
+            $groups[$normalized]['count']++;
+            $groups[$normalized]['totalMs'] += $query['time'];
+        }
+
+        uasort($groups, static fn (array $a, array $b): int => $b['totalMs'] <=> $a['totalMs']);
+
+        $rows = [];
+
+        foreach (array_slice($groups, 0, (int)$this->option('limit'), true) as $sql => $stats) {
+            $rows[] = [
+                number_format($stats['totalMs'], 1),
+                number_format($stats['count']),
+                $dominionCount ? number_format($stats['count'] / $dominionCount, 2) : '-',
+                mb_strimwidth($sql, 0, 90, '...'),
+            ];
+        }
+
+        $this->line('  Slowest statements by total time - repeats per dominion above ~1 are N+1s:');
+        $this->table(['total ms', 'runs', 'per dom', 'statement'], $rows);
+    }
+
+    private function percentage(float $part, float $whole): string
+    {
+        if ($whole <= 0) {
+            return '0';
+        }
+
+        return number_format(($part / $whole) * 100, 0);
+    }
+}

--- a/src/Console/Commands/Development/TickProfileCommand.php
+++ b/src/Console/Commands/Development/TickProfileCommand.php
@@ -34,7 +34,10 @@ class TickProfileCommand extends Command implements CommandInterface
                              {--round= : Round id to profile. Defaults to the most recent active round.}
                              {--commit : Keep the tick. By default everything is rolled back.}
                              {--rankings : Also profile updateDailyRankings(), which is where finding 4.1 lives.}
-                             {--limit=15 : How many repeated statements to list.}';
+                             {--limit=15 : How many repeated statements to list.}
+                             {--sample : Attribute PHP time to functions with the excimer sampling profiler. Requires the benchmark image.}
+                             {--period=0.001 : Sampling period in seconds for --sample.}
+                             {--collapsed= : Write folded stacks to this path for flamegraph rendering.}';
 
     /** @var string The console command description. */
     protected $description = 'Profiles a real tick at production scale and reports query counts and timings.';
@@ -168,6 +171,8 @@ class TickProfileCommand extends Command implements CommandInterface
 
     private function profileTick(Round $round, int $dominionCount): void
     {
+        $sampler = $this->startSampler();
+
         $this->profiler->start();
         $startedAt = hrtime(true);
 
@@ -182,6 +187,97 @@ class TickProfileCommand extends Command implements CommandInterface
         $queries = $this->profiler->stop();
 
         $this->report('performTick()', $queries, $wallMs, $dominionCount);
+        $this->reportSamples($sampler);
+    }
+
+    /**
+     * Starts the excimer sampling profiler, if --sample was passed and the
+     * extension is present.
+     *
+     * Query counts tell you nothing about the ~75% of the tick that is spent in
+     * PHP rather than in the driver. This is what attributes that share to
+     * actual functions.
+     *
+     * @return \ExcimerProfiler|null
+     */
+    private function startSampler(): ?object
+    {
+        if (!$this->option('sample')) {
+            return null;
+        }
+
+        if (!extension_loaded('excimer')) {
+            $this->warn('--sample needs the excimer extension; run this in the benchmark image:');
+            $this->warn('  docker compose run --rm benchmark php artisan dev:tick:profile --sample');
+            $this->line('');
+
+            return null;
+        }
+
+        $profiler = new \ExcimerProfiler();
+        $profiler->setPeriod((float)$this->option('period'));
+        $profiler->setEventType(EXCIMER_REAL);
+        $profiler->start();
+
+        return $profiler;
+    }
+
+    /**
+     * @param \ExcimerProfiler|null $sampler
+     */
+    private function reportSamples(?object $sampler): void
+    {
+        if ($sampler === null) {
+            return;
+        }
+
+        $sampler->stop();
+        $log = $sampler->getLog();
+
+        $collapsedPath = $this->option('collapsed');
+
+        if ($collapsedPath) {
+            $directory = dirname($collapsedPath);
+
+            if (!is_dir($directory)) {
+                mkdir($directory, 0755, true);
+            }
+
+            file_put_contents($collapsedPath, $log->formatCollapsed());
+            $this->line(sprintf('  folded stacks written to %s', $collapsedPath));
+        }
+
+        $aggregated = $log->aggregateByFunction();
+
+        if ($aggregated === []) {
+            $this->warn('  excimer collected no samples - the run may have been too short for the sampling period.');
+
+            return;
+        }
+
+        $totalSamples = array_sum(array_column($aggregated, 'self'));
+
+        $this->line('');
+        $this->info(sprintf('PHP time by function (%s samples at %ss)', number_format($totalSamples), $this->option('period')));
+        $this->line(str_repeat('-', 72));
+
+        // Self time is what identifies the function actually burning CPU;
+        // inclusive time identifies the caller responsible for it. Both are
+        // needed - a hot leaf is useless without knowing who calls it.
+        uasort($aggregated, static fn (array $a, array $b): int => $b['self'] <=> $a['self']);
+
+        $rows = [];
+
+        foreach (array_slice($aggregated, 0, (int)$this->option('limit'), true) as $function => $counts) {
+            $rows[] = [
+                number_format($counts['self']),
+                sprintf('%.1f%%', $totalSamples > 0 ? ($counts['self'] / $totalSamples) * 100 : 0),
+                number_format($counts['inclusive']),
+                mb_strimwidth($function, 0, 78, '...'),
+            ];
+        }
+
+        $this->table(['self', 'self %', 'incl', 'function'], $rows);
     }
 
     private function profileRankings(bool $commit): void

--- a/src/Console/Commands/Development/TickProfileCommand.php
+++ b/src/Console/Commands/Development/TickProfileCommand.php
@@ -70,7 +70,7 @@ class TickProfileCommand extends Command implements CommandInterface
         $this->line('');
         $this->info(sprintf('Profiling round %d (%s)', $round->id, $round->name));
         $this->line(sprintf('  active dominions   %s', number_format($dominionCount)));
-        $this->line(sprintf('  mode               %s', $commit ? 'COMMIT - the tick will be kept' : 'rollback - nothing is kept'));
+        $this->line(sprintf('  mode               %s', $commit ? 'COMMIT - the tick will be kept' : 'rollback - nothing is kept, mail discarded'));
         $this->line('');
 
         if ($commit && !$this->confirmCommit($round, $dominionCount)) {
@@ -78,18 +78,30 @@ class TickProfileCommand extends Command implements CommandInterface
             return;
         }
 
-        $this->warmUp($round);
+        if (!$commit) {
+            // A database rollback cannot recall an email. The hourly digest
+            // notification is ShouldQueue and the default queue connection is
+            // sync, so it would be delivered inline part-way through a
+            // profiling run. Discard mail for the duration instead.
+            config(['mail.default' => 'array']);
+        }
 
         if ($commit) {
+            $this->warmUp($round);
             $this->profileTick($round, $dominionCount);
         } else {
+            // Warm-up runs inside the transaction too: it calls
+            // precalculateTick(), which saves, so leaving it outside meant the
+            // command persisted one dominion's prediction while reporting that
+            // nothing was kept.
             $this->withRollback(function () use ($round, $dominionCount): void {
+                $this->warmUp($round);
                 $this->profileTick($round, $dominionCount);
             });
         }
 
         if ($this->option('rankings')) {
-            $this->profileRankings($commit);
+            $this->profileRankings($round, $commit);
         }
     }
 
@@ -280,14 +292,22 @@ class TickProfileCommand extends Command implements CommandInterface
         $this->table(['self', 'self %', 'incl', 'function'], $rows);
     }
 
-    private function profileRankings(bool $commit): void
+    /**
+     * Profiles the ranking pass for the round being profiled.
+     *
+     * Calls updateDailyRankingsForRound() rather than the scheduler's
+     * updateDailyRankings(), which sweeps every eligible round and skips any
+     * whose start hour is not the current hour - so it profiled a no-op for 23
+     * hours out of 24, and never the round named by --round.
+     */
+    private function profileRankings(Round $round, bool $commit): void
     {
-        $run = function (): array {
+        $run = function () use ($round): array {
             $this->profiler->start();
             $startedAt = hrtime(true);
 
             try {
-                $this->tickService->updateDailyRankings();
+                $this->tickService->updateDailyRankingsForRound($round);
             } catch (Throwable $e) {
                 $this->profiler->stop();
                 throw $e;

--- a/src/Console/Commands/Game/TickCommand.php
+++ b/src/Console/Commands/Game/TickCommand.php
@@ -3,6 +3,7 @@
 namespace OpenDominion\Console\Commands\Game;
 
 use Illuminate\Console\Command;
+use Laravel\Pulse\Facades\Pulse;
 use OpenDominion\Console\Commands\CommandInterface;
 use OpenDominion\Jobs\DailyRankingsAndStatsJob;
 use OpenDominion\Services\Dominion\TickService;
@@ -33,8 +34,18 @@ class TickCommand extends Command implements CommandInterface
      */
     public function handle(): void
     {
-        DailyRankingsAndStatsJob::dispatch();
-        $this->tickService->tickHourly();
-        $this->tickService->tickDaily();
+        // Pulse inspects every query to decide whether to record it, and the
+        // tick issues tens of thousands - profiled at ~7% of its PHP time for
+        // telemetry about a scheduled command nobody browses in the dashboard.
+        // Only this command is affected; web requests keep recording.
+        Pulse::stopRecording();
+
+        try {
+            DailyRankingsAndStatsJob::dispatch();
+            $this->tickService->tickHourly();
+            $this->tickService->tickDaily();
+        } finally {
+            Pulse::startRecording();
+        }
     }
 }

--- a/src/Console/Kernel.php
+++ b/src/Console/Kernel.php
@@ -15,7 +15,9 @@ class Kernel extends ConsoleKernel
      */
     protected function schedule(Schedule $schedule)
     {
-        $schedule->command('game:tick')->hourlyAt(0);
+        // Without the overlap guard, a tick running longer than an hour would
+        // have a second one start on top of it and apply phase A's deltas twice.
+        $schedule->command('game:tick')->hourlyAt(0)->withoutOverlapping(120);
         $schedule->command('game:ai')->hourlyAt(30);
 
         if (app()->environment('production')) {

--- a/src/Models/Dominion.php
+++ b/src/Models/Dominion.php
@@ -237,6 +237,26 @@ class Dominion extends AbstractModel
 
     public $calc = null;
 
+    /**
+     * Spell perks grouped as [category][key] => Collection<SpellPerkType>.
+     *
+     * Built lazily by getSpellPerksByCategory() and thrown away whenever the
+     * spells relation changes. Perk lookups are among the hottest operations in
+     * the game - ProductionCalculator alone resolves them ~26 times per
+     * pre-calculation, and each resolution used to walk every active spell and
+     * its perks from scratch.
+     *
+     * @var array<string, array<string, \Illuminate\Support\Collection>>|null
+     */
+    protected $spellPerksByCategory = null;
+
+    /**
+     * Tech perks grouped as [key] => Collection<TechPerkType>.
+     *
+     * @var array<string, \Illuminate\Support\Collection>|null
+     */
+    protected $techPerksByKey = null;
+
     // Relations
 
     public function councilThreads()
@@ -728,6 +748,88 @@ class Dominion extends AbstractModel
         return min($moraleGain, 100 - $this->morale);
     }
 
+    /**
+     * Discards the memoized perk groupings.
+     *
+     * Called from every route by which the underlying relations can change, so
+     * that no caller has to remember to invalidate anything. The cache's
+     * lifetime is exactly the loaded relation's lifetime - that is what makes it
+     * safe, and it is why nothing here is keyed on the dominion id.
+     */
+    protected function flushPerkCache(): void
+    {
+        $this->spellPerksByCategory = null;
+        $this->techPerksByKey = null;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * Eloquent funnels every relation population through here - eager loads,
+     * lazy loads, load() and refresh() alike - which makes it the one hook that
+     * cannot be bypassed by a normal relation read.
+     */
+    public function setRelation($relation, $value)
+    {
+        if ($relation === 'spells' || $relation === 'techs') {
+            $this->flushPerkCache();
+        }
+
+        return parent::setRelation($relation, $value);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function unsetRelation($relation)
+    {
+        if ($relation === 'spells' || $relation === 'techs') {
+            $this->flushPerkCache();
+        }
+
+        return parent::unsetRelation($relation);
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * Assigns $this->relations wholesale, bypassing setRelation(), so it needs
+     * its own hook.
+     */
+    public function setRelations(array $relations)
+    {
+        $this->flushPerkCache();
+
+        return parent::setRelations($relations);
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * As setRelations(): clears $this->relations directly.
+     */
+    public function unsetRelations()
+    {
+        $this->flushPerkCache();
+
+        return parent::unsetRelations();
+    }
+
+    /**
+     * PHP performs the shallow copy before this runs, so the clone would
+     * otherwise inherit a cache describing the original's relations.
+     * DominionSaved clones a dominion and then reloads its relations on the
+     * copy, which is exactly that situation.
+     */
+    public function __clone(): void
+    {
+        $this->flushPerkCache();
+    }
+
+    /**
+     * @deprecated Superseded by getSpellPerksByCategory(). Retained because it
+     *             is public API; no longer used internally.
+     */
     public function getSpellPerks() {
         return $this->spells->flatMap(
             function ($spell) {
@@ -742,22 +844,68 @@ class Dominion extends AbstractModel
     }
 
     /**
+     * Active spell perks, grouped by the casting spell's category and then by
+     * perk key.
+     *
+     * Grouping by category is what the TODO on getSpellPerkValue asked for. The
+     * category lives on the Spell, not the perk type, which is why the old code
+     * projected it onto each perk model on every call - writing an attribute
+     * that has no matching column. Here it is simply the outer array key.
+     *
+     * @return array<string, array<string, \Illuminate\Support\Collection>>
+     */
+    protected function getSpellPerksByCategory(): array
+    {
+        if ($this->spellPerksByCategory !== null) {
+            return $this->spellPerksByCategory;
+        }
+
+        $grouped = [];
+
+        foreach ($this->spells as $spell) {
+            foreach ($spell->perks as $perk) {
+                $grouped[$spell->category][$perk->key][] = $perk;
+            }
+        }
+
+        foreach ($grouped as $category => $keys) {
+            foreach ($keys as $key => $perks) {
+                $grouped[$category][$key] = collect($perks);
+            }
+        }
+
+        return $this->spellPerksByCategory = $grouped;
+    }
+
+    /**
      * @param string $key
      * @param array $types
      * @return float
      */
     public function getSpellPerkValue(string $key, array $types = ['self', 'friendly']): float
     {
-        // TODO: Group by category and remove resolveSpellPerk
-        $perks = $this->getSpellPerks()->whereIn('category', $types)->groupBy('key');
-        if (isset($perks[$key])) {
-            if ($perks[$key]->count() == 1) {
-                return $perks[$key]->first()->pivot->value;
+        $grouped = $this->getSpellPerksByCategory();
+
+        $perks = null;
+
+        foreach ($types as $type) {
+            $group = $grouped[$type][$key] ?? null;
+
+            if ($group === null) {
+                continue;
+            }
+
+            $perks = ($perks === null) ? $group : $perks->concat($group);
+        }
+
+        if ($perks !== null) {
+            if ($perks->count() == 1) {
+                return $perks->first()->pivot->value;
             }
             // Spell perks do not stack
-            $perkValue = (float)$perks[$key]->max('pivot.value');
+            $perkValue = (float)$perks->max('pivot.value');
             if ($perkValue < 0) {
-                $perkValue = (float)$perks[$key]->min('pivot.value');
+                $perkValue = (float)$perks->min('pivot.value');
             }
             return $perkValue;
         }
@@ -773,6 +921,9 @@ class Dominion extends AbstractModel
         return ($this->getSpellPerkValue($key) / 100);
     }
 
+    /**
+     * @deprecated Superseded by getTechPerksByKey(). No longer used internally.
+     */
     protected function getTechPerks() {
         return $this->techs->flatMap(
             function ($tech) {
@@ -782,12 +933,43 @@ class Dominion extends AbstractModel
     }
 
     /**
+     * Tech perks grouped by key.
+     *
+     * Iteration order is preserved deliberately: tech perks stack via sum(), and
+     * floating-point addition is not associative, so reordering could shift a
+     * result in the last bits.
+     *
+     * @return array<string, \Illuminate\Support\Collection>
+     */
+    protected function getTechPerksByKey(): array
+    {
+        if ($this->techPerksByKey !== null) {
+            return $this->techPerksByKey;
+        }
+
+        $grouped = [];
+
+        foreach ($this->techs as $tech) {
+            foreach ($tech->perks as $perk) {
+                $grouped[$perk->key][] = $perk;
+            }
+        }
+
+        return $this->techPerksByKey = array_map(
+            static function (array $perks) {
+                return collect($perks);
+            },
+            $grouped
+        );
+    }
+
+    /**
      * @param string $key
      * @return float
      */
     public function getTechPerkValue(string $key): float
     {
-        $perks = $this->getTechPerks()->groupBy('key');
+        $perks = $this->getTechPerksByKey();
         if (isset($perks[$key])) {
             return (float)$perks[$key]->sum('pivot.value');
         }

--- a/src/Models/Round.php
+++ b/src/Models/Round.php
@@ -52,22 +52,56 @@ class Round extends AbstractModel
         'updated_at' => 'datetime',
     ];
 
+    /**
+     * Per-process memo sitting in front of the shared cache.
+     *
+     * @var array<int, Round>
+     */
+    private static array $memoizedRounds = [];
+
     protected static function booted(): void
     {
         static::saved(static function (Round $round): void {
-            Cache::forget("game:round:{$round->id}");
+            static::forgetCached($round->id);
         });
 
         static::deleted(static function (Round $round): void {
-            Cache::forget("game:round:{$round->id}");
+            static::forgetCached($round->id);
         });
     }
 
+    /**
+     * Returns a round, avoiding both a query and a cache round-trip.
+     *
+     * The shared cache alone is not enough here. Dominion::scopeWithCachedRound
+     * calls this once per dominion, and every dominion in a round shares an id,
+     * so an hourly tick over a few hundred dominions turned into that many
+     * locked file reads and unserializes of the same row - profiled at ~40% of
+     * the tick's PHP time, and the single largest cost in it.
+     */
     public static function findCached(int $id): Round
     {
-        return Cache::rememberForever("game:round:{$id}", static function () use ($id) {
-            return Round::findOrFail($id);
-        });
+        if (!isset(static::$memoizedRounds[$id])) {
+            static::$memoizedRounds[$id] = Cache::rememberForever("game:round:{$id}", static function () use ($id) {
+                return Round::findOrFail($id);
+            });
+        }
+
+        // Cloned so each caller still gets its own instance, exactly as it did
+        // when every lookup deserialized a fresh copy. InvadeActionService
+        // writes to $dominion->round, and callers should not see each other's
+        // in-flight mutations.
+        return clone static::$memoizedRounds[$id];
+    }
+
+    /**
+     * Drops a round from both the memo and the shared cache.
+     */
+    public static function forgetCached(int $id): void
+    {
+        unset(static::$memoizedRounds[$id]);
+
+        Cache::forget("game:round:{$id}");
     }
 
     // Eloquent Relations

--- a/src/Services/Activity/ActivityService.php
+++ b/src/Services/Activity/ActivityService.php
@@ -41,7 +41,12 @@ class ActivityService
 
         $deviceString = null;
 
-        if ($userAgent === 'Symfony/3.X') {
+        // There is no browser behind a console request. The 'Symfony/3.X' test
+        // used to catch this, but Symfony's synthetic console user agent has
+        // been plain 'Symfony' since v4, so the guard silently stopped firing
+        // and every tick ran Mobile_Detect's full regex battery once per
+        // dominion to describe a device that does not exist.
+        if ($userAgent === null || $userAgent === 'Symfony' || $userAgent === 'Symfony/3.X' || app()->runningInConsole()) {
             $deviceString = 'Unknown';
 
         } else {

--- a/src/Services/Dominion/TickService.php
+++ b/src/Services/Dominion/TickService.php
@@ -92,6 +92,13 @@ class TickService
     protected $wonderService;
 
     /**
+     * Spells keyed by id, memoized for the lifetime of a tick.
+     *
+     * @var Collection<int, Spell>|null
+     */
+    protected ?Collection $spellsById = null;
+
+    /**
      * TickService constructor.
      */
     public function __construct()
@@ -912,15 +919,41 @@ class TickService
         }, 5);
     }
 
+    /**
+     * The spell reference table, keyed by id and fetched once per tick.
+     *
+     * @return \Illuminate\Support\Collection<int, Spell>
+     */
+    protected function spellsById(): Collection
+    {
+        if ($this->spellsById === null) {
+            $this->spellsById = Spell::all()->keyBy('id');
+        }
+
+        return $this->spellsById;
+    }
+
     protected function cleanupActiveSpells(Dominion $dominion)
     {
-        $finished = DominionSpell::query()
+        $expired = DominionSpell::query()
             ->where('dominion_id', $dominion->id)
             ->where('duration', '<=', 0)
-            ->get()
-            ->map(function ($dominionSpell) {
-                return $dominionSpell->spell;
-            });
+            ->get();
+
+        if ($expired->isEmpty()) {
+            return;
+        }
+
+        // Resolved from the reference table, fetched once per tick, rather than
+        // $dominionSpell->spell, which lazily fetched one row per expiring
+        // spell per dominion.
+        $spellsById = $this->spellsById();
+
+        $finished = $expired
+            ->map(static function ($dominionSpell) use ($spellsById) {
+                return $spellsById->get($dominionSpell->spell_id);
+            })
+            ->filter();
 
         $beneficialSpells = $finished->filter(function ($spell) {
             return !$spell->isHarmful();
@@ -950,6 +983,12 @@ class TickService
             ->where('dominion_id', $dominion->id)
             ->where('hours', '<=', 0)
             ->get();
+
+        // Nothing arrived this hour: skip the delete rather than issue one that
+        // matches no rows. Most dominions are in this state most hours.
+        if ($finished->isEmpty()) {
+            return;
+        }
 
         foreach ($finished->groupBy('source') as $source => $group) {
             if ($source === 'operations') continue;
@@ -1009,13 +1048,27 @@ class TickService
         $this->queueService->setForTick(true);
 
         // Reset tick values
+        //
+        // Written as one raw assignment rather than ~80 individual sets. Each
+        // set went through Eloquent's cast machinery, and Model::hasCast()
+        // rebuilds the merged cast map every time - with a column per tracked
+        // resource that made this loop the largest single source of attribute
+        // churn in the tick. The key selection below is identical to the
+        // per-attribute version it replaces; '[]' is exactly what an array cast
+        // stores for an empty array.
+        $resetAttributes = [];
+
         foreach ($tick->getAttributes() as $attr => $value) {
-            if (!in_array($attr, ['id', 'dominion_id', 'updated_at', 'starvation_casualties', 'expiring_spells'], true)) {
-                $tick->{$attr} = 0;
-            } elseif ($attr === 'starvation_casualties' || $attr === 'expiring_spells') {
-                $tick->{$attr} = [];
+            if ($attr === 'starvation_casualties' || $attr === 'expiring_spells') {
+                $resetAttributes[$attr] = '[]';
+            } elseif (in_array($attr, ['id', 'dominion_id', 'updated_at'], true)) {
+                $resetAttributes[$attr] = $value;
+            } else {
+                $resetAttributes[$attr] = 0;
             }
         }
+
+        $tick->setRawAttributes($resetAttributes);
 
         // Refresh attributes - guards against tick concurrency writing
         // delta-style updates between the caller's request and this

--- a/src/Services/Dominion/TickService.php
+++ b/src/Services/Dominion/TickService.php
@@ -1247,39 +1247,51 @@ class TickService
                 }
             }
 
-            // Saving current statistics
-            DB::table('daily_rankings')->upsert(
-                $statistics,
-                ['dominion_id', 'key'],
-                ['dominion_name', 'race_name', 'realm_number', 'realm_name', 'value'],
-            );
+            DB::transaction(function () use ($round, $statistics) {
+                // Saving current statistics
+                //
+                // Chunked because Laravel binds one placeholder per column per
+                // row and the MySQL protocol caps a prepared statement at
+                // 65,535 of them, which eight-column rows reach at ~8,000.
+                foreach (array_chunk($statistics, 1000) as $chunk) {
+                    DB::table('daily_rankings')->upsert(
+                        $chunk,
+                        ['dominion_id', 'key'],
+                        ['dominion_name', 'race_name', 'realm_number', 'realm_name', 'value'],
+                    );
+                }
 
-            // Calculate ranks
-            $ranks = DB::table('daily_rankings AS a')
-                ->select(DB::raw('a.*, COUNT(b.value)+1 AS new_rank'))
-                ->leftJoin('daily_rankings AS b', function ($join) use ($round) {
-                    $join->on('a.value', '<', 'b.value');
-                    $join->on('a.key', '=', 'b.key');
-                    $join->where('b.round_id', $round->id);
-                })
-                ->where('a.round_id', $round->id)
-                ->groupBy('a.dominion_id', 'a.key', 'a.value')
-                ->orderBy('new_rank')
-                ->get()
-                ->map(function ($obj) {
-                    $obj->previous_rank = $obj->rank;
-                    $obj->rank = $obj->new_rank;
-                    unset($obj->new_rank);
-                    return (array) $obj;
-                })
-                ->toArray();
+                // Calculate ranks
+                //
+                // RANK() reproduces the previous COUNT(b.value)+1 self-join
+                // exactly: tied values share a rank and the next distinct value
+                // skips the gap. That is load-bearing - ValorCalculator scores
+                // rank non-linearly and several features key off rank == 1 - so
+                // DENSE_RANK and ROW_NUMBER are both behaviour changes.
+                //
+                // The old rank is read inside the derived table rather than
+                // assigned from daily_rankings.rank in the SET clause: this is a
+                // multi-table update, where assignment order is not guaranteed.
+                // Because the derived table carries a window function it cannot
+                // be merged, so it is always materialised before the first row
+                // is updated - which is also why this does not raise the
+                // "can't specify target table for update" error.
+                $ranked = DB::table('daily_rankings')
+                    ->select('id', 'rank as old_rank')
+                    ->selectRaw('RANK() OVER (PARTITION BY `key` ORDER BY `value` DESC) as new_rank')
+                    ->where('round_id', $round->id);
 
-            // Update ranks
-            DB::table('daily_rankings')->upsert(
-                $ranks,
-                ['dominion_id', 'key'],
-                ['rank', 'previous_rank'],
-            );
+                // The outer round_id filter is required, not redundant: without
+                // it the update scans daily_rankings across every round ever
+                // played instead of seeking on the round.
+                DB::table('daily_rankings')
+                    ->joinSub($ranked, 'ranked', 'ranked.id', '=', 'daily_rankings.id')
+                    ->where('daily_rankings.round_id', $round->id)
+                    ->update([
+                        'daily_rankings.rank' => DB::raw('ranked.new_rank'),
+                        'daily_rankings.previous_rank' => DB::raw('ranked.old_rank'),
+                    ]);
+            }, 5);
 
             Log::debug('Daily rankings finished');
 

--- a/src/Services/Dominion/TickService.php
+++ b/src/Services/Dominion/TickService.php
@@ -1241,6 +1241,9 @@ class TickService
         $this->queueService->setForTick(false);
     }
 
+    /**
+     * Scheduler entry point: ranks every round that is due this hour.
+     */
     public function updateDailyRankings(): void
     {
         // Update rankings
@@ -1252,108 +1255,121 @@ class TickService
                 continue;
             }
 
-            Log::debug('Daily rankings started');
+            $this->updateDailyRankingsForRound($round);
+        }
+    }
 
-            $activeDominions = $round->dominions()->with([
-                'race',
-                'realm',
-            ])->get();
+    /**
+     * Ranks a single round, without the once-a-day gate.
+     *
+     * Split out from updateDailyRankings() so callers that already know which
+     * round they want - dev:tick:profile in particular - are not at the mercy
+     * of the scheduler's hour check, which otherwise makes profiling a no-op
+     * for 23 hours out of 24.
+     */
+    public function updateDailyRankingsForRound(Round $round): void
+    {
+        Log::debug('Daily rankings started');
 
-            // Calculate current statistics
-            $statistics = [];
-            foreach ($activeDominions as $dominion) {
-                $isAbandoned = ($dominion->abandoned_at !== null && $dominion->abandoned_at < now());
-                $isLocked = $dominion->locked_at !== null;
+        $activeDominions = $round->dominions()->with([
+            'race',
+            'realm',
+        ])->get();
 
-                foreach ($this->rankingsHelper->getRankings() as $ranking) {
+        // Calculate current statistics
+        $statistics = [];
+        foreach ($activeDominions as $dominion) {
+            $isAbandoned = ($dominion->abandoned_at !== null && $dominion->abandoned_at < now());
+            $isLocked = $dominion->locked_at !== null;
 
-                    if ($ranking['stat'] == 'land') {
-                        $value = $this->landCalculator->getTotalLand($dominion);
-                    } elseif ($ranking['stat'] == 'networth') {
-                        $value = $this->networthCalculator->getDominionNetworth($dominion);
-                    } elseif ($ranking['stat'] == 'land_explored') {
-                        $value = max(0, $dominion->stat_total_land_explored - $dominion->stat_total_land_lost);
-                    } elseif ($ranking['stat'] == 'land_conquered') {
-                        $value = max(0, $dominion->stat_total_land_conquered - $dominion->stat_total_land_lost);
-                    } else {
-                        $value = $dominion->{$ranking['stat']};
-                    }
+            foreach ($this->rankingsHelper->getRankings() as $ranking) {
 
-                    $zeroOutRank = false;
-                    if($value != 0 && ($isAbandoned || $isLocked)) {
-                        $value = 0;
-                        $zeroOutRank = true;
-                    }
+                if ($ranking['stat'] == 'land') {
+                    $value = $this->landCalculator->getTotalLand($dominion);
+                } elseif ($ranking['stat'] == 'networth') {
+                    $value = $this->networthCalculator->getDominionNetworth($dominion);
+                } elseif ($ranking['stat'] == 'land_explored') {
+                    $value = max(0, $dominion->stat_total_land_explored - $dominion->stat_total_land_lost);
+                } elseif ($ranking['stat'] == 'land_conquered') {
+                    $value = max(0, $dominion->stat_total_land_conquered - $dominion->stat_total_land_lost);
+                } else {
+                    $value = $dominion->{$ranking['stat']};
+                }
 
-                    if ($value != 0 || $zeroOutRank) {
-                        $statistics[] = [
-                            'round_id' => $round->id,
-                            'dominion_id' => $dominion->id,
-                            'dominion_name' => $dominion->name,
-                            'race_name' => $dominion->race->name,
-                            'realm_number' => $dominion->realm->number,
-                            'realm_name' => $dominion->realm->name,
-                            'key' => $ranking['key'],
-                            'value' => $value,
-                        ];
-                    }
+                $zeroOutRank = false;
+                if($value != 0 && ($isAbandoned || $isLocked)) {
+                    $value = 0;
+                    $zeroOutRank = true;
+                }
+
+                if ($value != 0 || $zeroOutRank) {
+                    $statistics[] = [
+                        'round_id' => $round->id,
+                        'dominion_id' => $dominion->id,
+                        'dominion_name' => $dominion->name,
+                        'race_name' => $dominion->race->name,
+                        'realm_number' => $dominion->realm->number,
+                        'realm_name' => $dominion->realm->name,
+                        'key' => $ranking['key'],
+                        'value' => $value,
+                    ];
                 }
             }
-
-            DB::transaction(function () use ($round, $statistics) {
-                // Saving current statistics
-                //
-                // Chunked because Laravel binds one placeholder per column per
-                // row and the MySQL protocol caps a prepared statement at
-                // 65,535 of them, which eight-column rows reach at ~8,000.
-                foreach (array_chunk($statistics, 1000) as $chunk) {
-                    DB::table('daily_rankings')->upsert(
-                        $chunk,
-                        ['dominion_id', 'key'],
-                        ['dominion_name', 'race_name', 'realm_number', 'realm_name', 'value'],
-                    );
-                }
-
-                // Calculate ranks
-                //
-                // RANK() reproduces the previous COUNT(b.value)+1 self-join
-                // exactly: tied values share a rank and the next distinct value
-                // skips the gap. That is load-bearing - ValorCalculator scores
-                // rank non-linearly and several features key off rank == 1 - so
-                // DENSE_RANK and ROW_NUMBER are both behaviour changes.
-                //
-                // The old rank is read inside the derived table rather than
-                // assigned from daily_rankings.rank in the SET clause: this is a
-                // multi-table update, where assignment order is not guaranteed.
-                // Because the derived table carries a window function it cannot
-                // be merged, so it is always materialised before the first row
-                // is updated - which is also why this does not raise the
-                // "can't specify target table for update" error.
-                $ranked = DB::table('daily_rankings')
-                    ->select('id', 'rank as old_rank')
-                    ->selectRaw('RANK() OVER (PARTITION BY `key` ORDER BY `value` DESC) as new_rank')
-                    ->where('round_id', $round->id);
-
-                // The outer round_id filter is required, not redundant: without
-                // it the update scans daily_rankings across every round ever
-                // played instead of seeking on the round.
-                DB::table('daily_rankings')
-                    ->joinSub($ranked, 'ranked', 'ranked.id', '=', 'daily_rankings.id')
-                    ->where('daily_rankings.round_id', $round->id)
-                    ->update([
-                        'daily_rankings.rank' => DB::raw('ranked.new_rank'),
-                        'daily_rankings.previous_rank' => DB::raw('ranked.old_rank'),
-                    ]);
-            }, 5);
-
-            Log::debug('Daily rankings finished');
-
-            // Update Valor rankings
-            Log::debug('Valor calculation started');
-            $valorService = app(ValorService::class);
-            $valorService->updateValor($round);
-            Log::debug('Valor calculation finished');
         }
+
+        DB::transaction(function () use ($round, $statistics) {
+            // Saving current statistics
+            //
+            // Chunked because Laravel binds one placeholder per column per
+            // row and the MySQL protocol caps a prepared statement at
+            // 65,535 of them, which eight-column rows reach at ~8,000.
+            foreach (array_chunk($statistics, 1000) as $chunk) {
+                DB::table('daily_rankings')->upsert(
+                    $chunk,
+                    ['dominion_id', 'key'],
+                    ['dominion_name', 'race_name', 'realm_number', 'realm_name', 'value'],
+                );
+            }
+
+            // Calculate ranks
+            //
+            // RANK() reproduces the previous COUNT(b.value)+1 self-join
+            // exactly: tied values share a rank and the next distinct value
+            // skips the gap. That is load-bearing - ValorCalculator scores
+            // rank non-linearly and several features key off rank == 1 - so
+            // DENSE_RANK and ROW_NUMBER are both behaviour changes.
+            //
+            // The old rank is read inside the derived table rather than
+            // assigned from daily_rankings.rank in the SET clause: this is a
+            // multi-table update, where assignment order is not guaranteed.
+            // Because the derived table carries a window function it cannot
+            // be merged, so it is always materialised before the first row
+            // is updated - which is also why this does not raise the
+            // "can't specify target table for update" error.
+            $ranked = DB::table('daily_rankings')
+                ->select('id', 'rank as old_rank')
+                ->selectRaw('RANK() OVER (PARTITION BY `key` ORDER BY `value` DESC) as new_rank')
+                ->where('round_id', $round->id);
+
+            // The outer round_id filter is required, not redundant: without
+            // it the update scans daily_rankings across every round ever
+            // played instead of seeking on the round.
+            DB::table('daily_rankings')
+                ->joinSub($ranked, 'ranked', 'ranked.id', '=', 'daily_rankings.id')
+                ->where('daily_rankings.round_id', $round->id)
+                ->update([
+                    'daily_rankings.rank' => DB::raw('ranked.new_rank'),
+                    'daily_rankings.previous_rank' => DB::raw('ranked.old_rank'),
+                ]);
+        }, 5);
+
+        Log::debug('Daily rankings finished');
+
+        // Update Valor rankings
+        Log::debug('Valor calculation started');
+        $valorService = app(ValorService::class);
+        $valorService->updateValor($round);
+        Log::debug('Valor calculation finished');
     }
 
     public function tickDailyStats(): void

--- a/src/Services/Dominion/TickService.php
+++ b/src/Services/Dominion/TickService.php
@@ -400,6 +400,11 @@ class TickService
                     'race.units',
                     'race.units.perks',
                     'spells',
+                    // Without spells.perks, the first perk lookup of the tick
+                    // lazy-loads perks once per active spell per dominion -
+                    // roughly six queries each. performRaceUnitProduction below
+                    // is that first lookup.
+                    'spells.perks',
                     'techs',
                     'techs.perks',
                     'tick',
@@ -723,7 +728,10 @@ class TickService
      */
     public function tickDaily()
     {
-        foreach (Round::with('dominions')->active()->get() as $round) {
+        // No with('dominions'): the body below uses $round->realms() and
+        // $round->dominions(), both fresh query builders, so eager-loading the
+        // relation hydrates a model per dominion in the round and reads none.
+        foreach (Round::active()->get() as $round) {
             // Only runs once daily
             if ($round->start_date->hour != now()->hour) {
                 continue;
@@ -852,15 +860,23 @@ class TickService
     {
         DB::transaction(function () use ($dominions) {
             foreach ($dominions as $dominion) {
+                // Check the race first: only one race has a summoning unit, and
+                // races are cached, so this is near-free. resolveSpellPerk is
+                // not - it expands to five or six full perk-collection walks.
+                $summoningUnits = $dominion->race->units->filter(
+                    static fn ($unit): bool => (bool)$unit->getPerkValue('summons_unit')
+                );
+
+                if ($summoningUnits->isEmpty()) {
+                    continue;
+                }
+
                 if ($this->spellCalculator->resolveSpellPerk($dominion, 'disable_unit_summoning') > 0) {
                     continue;
                 }
 
-                foreach ($dominion->race->units as $sourceUnit) {
+                foreach ($summoningUnits as $sourceUnit) {
                     $perkValue = $sourceUnit->getPerkValue('summons_unit');
-                    if (!$perkValue) {
-                        continue;
-                    }
 
                     [$targetSlot, $perSource, $capPerSource] = array_map('intval', explode(',', $perkValue));
                     if ($targetSlot < 1 || $perSource < 1) {
@@ -1036,9 +1052,6 @@ class TickService
             'race.units.perks',
         ]);
 
-        // Active spells
-        $this->spellCalculator->getActiveSpells($dominion);
-
         // Queues
         $incomingQueue = DB::table('dominion_queue')
             ->where('dominion_id', $dominion->id)
@@ -1067,24 +1080,41 @@ class TickService
         $tick->military_draftees = $drafteesGrowthRate;
 
         // Resources
+        //
+        // Each value is computed once and the net changes derived from those
+        // locals. Calling the getNetChange() helpers here instead would
+        // recompute production and decay a second time, and every one of those
+        // walks the full raw x multiplier chain including a resolveSpellPerk.
+        // The arithmetic below mirrors ProductionCalculator::get*NetChange()
+        // exactly, round() included.
+        $lumberProduction = $this->productionCalculator->getLumberProduction($dominion);
+        $lumberDecay = $this->productionCalculator->getLumberDecay($dominion);
+        $manaProduction = $this->productionCalculator->getManaProduction($dominion);
+        $manaDecay = $this->productionCalculator->getManaDecay($dominion);
+        $boatProduction = $this->productionCalculator->getBoatProduction($dominion);
+        $foodProduction = $this->productionCalculator->getFoodProduction($dominion);
+        $foodDecay = $this->productionCalculator->getFoodDecay($dominion);
+
         $tick->resource_platinum += $this->productionCalculator->getPlatinumProduction($dominion);
-        $tick->resource_lumber_production += $this->productionCalculator->getLumberProduction($dominion);
-        $tick->resource_lumber_decay += $this->productionCalculator->getLumberDecay($dominion);
-        $tick->resource_lumber += $this->productionCalculator->getLumberNetChange($dominion);
-        $tick->resource_mana_production += $this->productionCalculator->getManaProduction($dominion);
-        $tick->resource_mana_decay += $this->productionCalculator->getManaDecay($dominion);
-        $tick->resource_mana += $this->productionCalculator->getManaNetChange($dominion);
+        $tick->resource_lumber_production += $lumberProduction;
+        $tick->resource_lumber_decay += $lumberDecay;
+        $tick->resource_lumber += (int)round($lumberProduction - $lumberDecay);
+        $tick->resource_mana_production += $manaProduction;
+        $tick->resource_mana_decay += $manaDecay;
+        $tick->resource_mana += (int)round($manaProduction - $manaDecay);
         $tick->resource_ore += $this->productionCalculator->getOreProduction($dominion);
         $tick->resource_gems += $this->productionCalculator->getGemProduction($dominion);
         $tick->resource_tech += $this->productionCalculator->getTechProduction($dominion);
-        $tick->resource_boats += $this->productionCalculator->getBoatProduction($dominion);
-        $tick->resource_boat_production += $this->productionCalculator->getBoatProduction($dominion);
-        $tick->resource_food_production += $this->productionCalculator->getFoodProduction($dominion);
-        $tick->resource_food_decay += $this->productionCalculator->getFoodDecay($dominion);
+        $tick->resource_boats += $boatProduction;
+        $tick->resource_boat_production += $boatProduction;
+        $tick->resource_food_production += $foodProduction;
+        $tick->resource_food_decay += $foodDecay;
         // Special case for Alchemist Flame
         $tick->improvement_forges += (int)($dominion->building_alchemy * $dominion->getSpellPerkValue('alchemy_improvement_forges_raw'));
         // Check for starvation before adjusting food
-        $foodNetChange = $this->productionCalculator->getFoodNetChange($dominion);
+        $foodNetChange = (int)round(
+            $foodProduction - $this->productionCalculator->getFoodConsumption($dominion) - $foodDecay
+        );
 
         // Starvation casualties
         if (($dominion->resource_food + $foodNetChange) < 0) {

--- a/src/Services/QueryProfilerService.php
+++ b/src/Services/QueryProfilerService.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace OpenDominion\Services;
+
+use DB;
+use Illuminate\Database\Events\QueryExecuted;
+
+/**
+ * Records the queries issued by a callback.
+ *
+ * Lives in src/ rather than tests/ because both the benchmark suite and the
+ * dev:tick:profile command depend on it, and their numbers are only comparable
+ * if they normalize and attribute SQL identically. tests/ is autoload-dev, so a
+ * console command cannot reach into it.
+ *
+ * A single listener is attached lazily and gated by a recording flag: Laravel
+ * offers no way to detach a DB::listen callback, so registering one per
+ * measurement would double-count every subsequent run.
+ *
+ * @phpstan-type QueryRecord array{sql: string, bindings: array, time: float}
+ */
+class QueryProfilerService
+{
+    private bool $listening = false;
+
+    private bool $recording = false;
+
+    /** @var array<int, array{sql: string, bindings: array, time: float}> */
+    private array $queries = [];
+
+    /**
+     * Begins recording, discarding anything captured previously.
+     */
+    public function start(): void
+    {
+        $this->attachListener();
+
+        $this->queries = [];
+        $this->recording = true;
+    }
+
+    /**
+     * Stops recording and returns what was captured.
+     *
+     * @return array<int, array{sql: string, bindings: array, time: float}>
+     */
+    public function stop(): array
+    {
+        $this->recording = false;
+
+        return $this->queries;
+    }
+
+    /**
+     * Runs a callback with recording suspended. Used to exclude warm-up work
+     * from a measurement.
+     *
+     * @template T
+     * @param callable(): T $callback
+     * @return T
+     */
+    public function withoutRecording(callable $callback)
+    {
+        $wasRecording = $this->recording;
+        $this->recording = false;
+
+        try {
+            return $callback();
+        } finally {
+            $this->recording = $wasRecording;
+        }
+    }
+
+    /**
+     * Collapses bind-list width and whitespace so the same logical statement
+     * groups together regardless of how many ids it was called with.
+     */
+    public static function normalize(string $sql): string
+    {
+        $sql = preg_replace('/\s+/', ' ', trim($sql));
+        $sql = preg_replace('/\(\s*\?(?:\s*,\s*\?)*\s*\)/', '(?)', $sql);
+
+        return $sql;
+    }
+
+    /**
+     * The first table named by a statement, which is the one people reason about
+     * when attributing cost.
+     */
+    public static function primaryTable(string $sql): ?string
+    {
+        if (preg_match('/\b(?:from|into|update|join)\s+`?([a-zA-Z0-9_]+)`?/i', $sql, $matches) === 1) {
+            return $matches[1];
+        }
+
+        return null;
+    }
+
+    private function attachListener(): void
+    {
+        if ($this->listening) {
+            return;
+        }
+
+        DB::listen(function (QueryExecuted $query): void {
+            if (!$this->recording) {
+                return;
+            }
+
+            $this->queries[] = [
+                'sql' => $query->sql,
+                'bindings' => $query->bindings,
+                'time' => (float)$query->time,
+            ];
+        });
+
+        $this->listening = true;
+    }
+}

--- a/storage/profiles/.gitignore
+++ b/storage/profiles/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/tests/Benchmark/AbstractTickBenchmarkTestCase.php
+++ b/tests/Benchmark/AbstractTickBenchmarkTestCase.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace OpenDominion\Tests\Benchmark;
+
+use OpenDominion\Factories\DominionFactory;
+use OpenDominion\Factories\RealmFactory;
+use OpenDominion\Models\Dominion;
+use OpenDominion\Models\Race;
+use OpenDominion\Models\Round;
+use OpenDominion\Services\Dominion\TickService;
+use OpenDominion\Tests\AbstractTestCase;
+use OpenDominion\Tests\Benchmark\Support\BenchmarkRound;
+use OpenDominion\Tests\Benchmark\Support\BenchmarkRoundSeeder;
+use OpenDominion\Tests\Benchmark\Support\TickProfiler;
+
+/**
+ * Shared harness for the benchmark suites.
+ *
+ * Concrete subclasses must carry their own #[Group('benchmark')] attribute -
+ * PHPUnit reads attributes off the test class itself and does not inherit them.
+ */
+abstract class AbstractTickBenchmarkTestCase extends AbstractTestCase
+{
+    protected TickProfiler $profiler;
+
+    protected BenchmarkRoundSeeder $seeder;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->profiler = new TickProfiler();
+        $this->seeder = new BenchmarkRoundSeeder(
+            $this->app->make(DominionFactory::class),
+            $this->app->make(RealmFactory::class),
+            $this->app->make(TickService::class),
+        );
+    }
+
+    protected function tickService(): TickService
+    {
+        return $this->app->make(TickService::class);
+    }
+
+    /**
+     * Excludes one-off setup from the measurement: container singletons,
+     * autoloading, opcache, and the two rememberForever caches the tick reads
+     * through - Race::findWithRelationsCached and Round::findCached.
+     *
+     * EVERY fixture that will be measured has to be warmed, not just the first.
+     * The race cache is keyed per race id, so a larger round touches races a
+     * smaller one never did; leaving those cold would charge the larger run for
+     * cache population and fake a superlinear slope.
+     *
+     * What this deliberately hides: roughly one query per distinct race plus one
+     * per round. That is fixed reference-data cost, not per-dominion cost, and
+     * whether production pays it hourly depends on its cache driver.
+     *
+     * precalculateTick is deterministic, so re-running it on an already-seeded
+     * dominion leaves the fixture unchanged.
+     */
+    protected function warmUp(BenchmarkRound ...$fixtures): void
+    {
+        $tickService = $this->tickService();
+
+        foreach ($fixtures as $fixture) {
+            $raceIds = Dominion::whereIn('id', $fixture->dominionIds)
+                ->distinct()
+                ->pluck('race_id');
+
+            $dominion = Dominion::findOrFail($fixture->dominionIds[0]);
+
+            $this->profiler->warmUp(static function () use ($tickService, $fixture, $raceIds, $dominion): void {
+                Round::findCached($fixture->round->id);
+
+                foreach ($raceIds as $raceId) {
+                    Race::findWithRelationsCached($raceId);
+                }
+
+                $tickService->precalculateTick($dominion);
+            });
+        }
+    }
+
+    /**
+     * STDERR rather than echo: PHPUnit captures test output and, depending on
+     * configuration, flags it as risky. STDERR goes straight to the terminal.
+     */
+    protected function write(string $text): void
+    {
+        fwrite(STDERR, $text);
+    }
+}

--- a/tests/Benchmark/AbstractTickBenchmarkTestCase.php
+++ b/tests/Benchmark/AbstractTickBenchmarkTestCase.php
@@ -90,4 +90,25 @@ abstract class AbstractTickBenchmarkTestCase extends AbstractTestCase
     {
         fwrite(STDERR, $text);
     }
+
+    /**
+     * Reports where a measurement sits against its budget, pass or fail.
+     *
+     * A budget test that only speaks up when it breaks tells you nothing about
+     * headroom - you cannot see a change eating 90% of the allowance until it
+     * eats 101%. Printing every run also means the numbers to ratchet to are
+     * already on screen after an optimization lands.
+     */
+    protected function reportBudget(string $label, float $measured, float $budget, string $unit = 'queries'): void
+    {
+        $this->write(sprintf(
+            '  %-46s %10.2f / %8.2f %s  (%.0f%% of budget)%s',
+            $label,
+            $measured,
+            $budget,
+            $unit,
+            $budget > 0 ? ($measured / $budget) * 100 : 0,
+            PHP_EOL
+        ));
+    }
 }

--- a/tests/Benchmark/Support/BenchmarkRound.php
+++ b/tests/Benchmark/Support/BenchmarkRound.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace OpenDominion\Tests\Benchmark\Support;
+
+use OpenDominion\Models\Round;
+
+/**
+ * The fixture produced by BenchmarkRoundSeeder.
+ */
+final class BenchmarkRound
+{
+    /**
+     * @param array<int, int> $dominionIds
+     */
+    public function __construct(
+        public readonly Round $round,
+        public readonly array $dominionIds,
+        public readonly int $realmCount,
+        public readonly int $playerCount,
+        public readonly int $queueRowCount,
+        public readonly int $spellRowCount,
+    ) {
+    }
+
+    public function dominionCount(): int
+    {
+        return count($this->dominionIds);
+    }
+
+    public function describe(): string
+    {
+        return sprintf(
+            '%d dominions across %d realms (%d with users, %d bots), %d queue rows, %d spell rows',
+            $this->dominionCount(),
+            $this->realmCount,
+            $this->playerCount,
+            $this->dominionCount() - $this->playerCount,
+            $this->queueRowCount,
+            $this->spellRowCount
+        );
+    }
+}

--- a/tests/Benchmark/Support/BenchmarkRound.php
+++ b/tests/Benchmark/Support/BenchmarkRound.php
@@ -19,6 +19,8 @@ final class BenchmarkRound
         public readonly int $playerCount,
         public readonly int $queueRowCount,
         public readonly int $spellRowCount,
+        public readonly int $specialSpellCount = 0,
+        public readonly int $protectionCount = 0,
     ) {
     }
 
@@ -27,16 +29,40 @@ final class BenchmarkRound
         return count($this->dominionIds);
     }
 
+    /**
+     * Dominions carrying a spell that makes performSpellEffects call
+     * Dominion::update(), which fires DominionSaved and so pays for a second
+     * precalculateTick. Seeded onto the front of the list.
+     *
+     * @return array<int, int>
+     */
+    public function affectedDominionIds(): array
+    {
+        return array_slice($this->dominionIds, 0, $this->specialSpellCount);
+    }
+
+    /**
+     * The rest - the common case, which should precalculate exactly once.
+     *
+     * @return array<int, int>
+     */
+    public function unaffectedDominionIds(): array
+    {
+        return array_slice($this->dominionIds, $this->specialSpellCount);
+    }
+
     public function describe(): string
     {
         return sprintf(
-            '%d dominions across %d realms (%d with users, %d bots), %d queue rows, %d spell rows',
+            '%d dominions across %d realms (%d with users, %d bots), %d queue rows, %d spell rows, %d with special spells, %d in protection',
             $this->dominionCount(),
             $this->realmCount,
             $this->playerCount,
             $this->dominionCount() - $this->playerCount,
             $this->queueRowCount,
-            $this->spellRowCount
+            $this->spellRowCount,
+            $this->specialSpellCount,
+            $this->protectionCount
         );
     }
 }

--- a/tests/Benchmark/Support/BenchmarkRoundSeeder.php
+++ b/tests/Benchmark/Support/BenchmarkRoundSeeder.php
@@ -12,6 +12,7 @@ use OpenDominion\Models\Race;
 use OpenDominion\Models\Realm;
 use OpenDominion\Models\Round;
 use OpenDominion\Models\Spell;
+use OpenDominion\Models\SpellPerkType;
 use OpenDominion\Models\User;
 use OpenDominion\Services\Dominion\TickService;
 use RuntimeException;
@@ -81,6 +82,35 @@ final class BenchmarkRoundSeeder
     private const FACTORY_SEEDED_SPELL_KEYS = ['ares_call', 'midas_touch'];
 
     /**
+     * Perks that give performSpellEffects (TickService.php:762) per-dominion work
+     * ending in a Dominion::update(), which fires DominionSaved and so runs a
+     * SECOND precalculateTick for that dominion.
+     *
+     * These must NOT go on every dominion. They sit on the highest-perk spells,
+     * so a naive "pick the spells with the most perks" fixture puts them on all
+     * of them and makes the double-precalculation look universal when in
+     * production it is confined to the dominions actually carrying these spells.
+     *
+     * @var array<int, string>
+     */
+    private const SPECIAL_PERK_KEYS = [
+        'upgrade_specs',
+        'convert_peasants_to_self_military_unit1',
+        'wizard_guilds_produce_military_unit3',
+    ];
+
+    /** Fraction of dominions carrying one of the SPECIAL_PERK_KEYS spells. */
+    private const SPECIAL_SPELL_RATIO = 0.1;
+
+    /**
+     * performSpellEffects converts expired burning / lightning_storm rows into
+     * this spell by UPDATEing dominion_spells.spell_id. If the dominion already
+     * holds a row for it, that update collides on the (dominion_id, spell_id)
+     * primary key - so it must never be seeded directly.
+     */
+    private const CONVERSION_TARGET_SPELL_KEY = 'rejuvenation';
+
+    /**
      * Durations assigned to the beneficial and harmful spells picked below.
      *
      * A duration of 1 decrements to 0 and drives cleanupActiveSpells (and the
@@ -91,8 +121,15 @@ final class BenchmarkRoundSeeder
      */
     private const BENEFICIAL_DURATIONS = [1, 2, 6, 10];
 
-    /** @var array<int, int> */
-    private const HARMFUL_DURATIONS = [1, 8];
+    /**
+     * Ordered against the harmful spells picked below, which sort as
+     * [lightning_bolt, burning]. Burning gets duration 1 so it decrements to 0
+     * and drives the burning -> rejuvenation conversion in performSpellEffects,
+     * which is only safe because CONVERSION_TARGET_SPELL_KEY is never seeded.
+     *
+     * @var array<int, int>
+     */
+    private const HARMFUL_DURATIONS = [8, 1];
 
     public function __construct(
         private readonly DominionFactory $dominionFactory,
@@ -101,13 +138,23 @@ final class BenchmarkRoundSeeder
     ) {
     }
 
-    public function seed(int $dominionCount): BenchmarkRound
+    /**
+     * @param int $inProtectionCount How many of the dominions are still in
+     *        protection. Phase A skips them (protection_finished = true is part
+     *        of its where clause at TickService.php:275) while phase B does not,
+     *        which is finding M1 of secondroundfindings.txt.
+     */
+    public function seed(int $dominionCount, int $inProtectionCount = 0): BenchmarkRound
     {
         if ($dominionCount < 1) {
             throw new RuntimeException('Benchmark fixtures need at least one dominion.');
         }
 
-        return $this->withDeterministicRandomness(function () use ($dominionCount): BenchmarkRound {
+        if ($inProtectionCount > $dominionCount) {
+            throw new RuntimeException('Cannot put more dominions in protection than exist.');
+        }
+
+        return $this->withDeterministicRandomness(function () use ($dominionCount, $inProtectionCount): BenchmarkRound {
             $round = $this->createRound();
             $races = $this->racesByAlignment();
 
@@ -130,6 +177,8 @@ final class BenchmarkRoundSeeder
             $playerCount = $this->attachUsers($dominionIds);
             $this->seedQueues($dominionIds);
             $this->seedSpells($dominionIds);
+            $specialSpellCount = $this->seedSpecialSpells($dominionIds);
+            $this->applyProtection($dominionIds, $inProtectionCount);
 
             $this->precalculate($dominionIds);
 
@@ -139,7 +188,9 @@ final class BenchmarkRoundSeeder
                 $realmCount,
                 $playerCount,
                 DB::table('dominion_queue')->whereIn('dominion_id', $dominionIds)->count(),
-                DB::table('dominion_spells')->whereIn('dominion_id', $dominionIds)->count()
+                DB::table('dominion_spells')->whereIn('dominion_id', $dominionIds)->count(),
+                $specialSpellCount,
+                $inProtectionCount
             );
         });
     }
@@ -226,6 +277,28 @@ final class BenchmarkRoundSeeder
     }
 
     /**
+     * Puts the LAST $count dominions into protection, so the special-spell
+     * dominions at the front of the list stay independent of this.
+     *
+     * @param array<int, int> $dominionIds
+     */
+    private function applyProtection(array $dominionIds, int $count): void
+    {
+        if ($count < 1) {
+            return;
+        }
+
+        $ids = array_slice($dominionIds, -$count);
+
+        DB::table('dominions')
+            ->whereIn('id', $ids)
+            ->update([
+                'protection_finished' => false,
+                'protection_ticks_remaining' => 24,
+            ]);
+    }
+
+    /**
      * @param array<int, int> $dominionIds
      */
     private function seedQueues(array $dominionIds): void
@@ -305,8 +378,14 @@ final class BenchmarkRoundSeeder
             ->orderBy('id')
             ->get();
 
+        $excludedKeys = array_merge(
+            self::FACTORY_SEEDED_SPELL_KEYS,
+            [self::CONVERSION_TARGET_SPELL_KEY],
+            $this->specialSpellKeys()
+        );
+
         $spells = $spells->reject(
-            fn (Spell $spell): bool => in_array($spell->key, self::FACTORY_SEEDED_SPELL_KEYS, true)
+            fn (Spell $spell): bool => in_array($spell->key, $excludedKeys, true)
         );
 
         $beneficial = $spells->reject(fn (Spell $spell): bool => $spell->isHarmful())
@@ -322,6 +401,66 @@ final class BenchmarkRoundSeeder
         }
 
         return [$beneficial, $harmful];
+    }
+
+    /**
+     * The spells carrying SPECIAL_PERK_KEYS, resolved through the perk types so
+     * this tracks the game data rather than hardcoding spell keys.
+     *
+     * @return array<int, string>
+     */
+    private function specialSpellKeys(): array
+    {
+        return SpellPerkType::whereIn('key', self::SPECIAL_PERK_KEYS)
+            ->with('spells')
+            ->get()
+            ->flatMap(fn (SpellPerkType $perkType): Collection => $perkType->spells->pluck('key'))
+            ->unique()
+            ->values()
+            ->all();
+    }
+
+    /**
+     * Puts a special spell on SPECIAL_SPELL_RATIO of the dominions so
+     * performSpellEffects' three per-dominion branches - and the second
+     * precalculateTick they trigger through DominionSaved - are exercised at a
+     * realistic rate rather than universally.
+     *
+     * @param array<int, int> $dominionIds
+     */
+    private function seedSpecialSpells(array $dominionIds): int
+    {
+        $spells = Spell::whereIn('key', $this->specialSpellKeys())->orderBy('id')->get();
+
+        if ($spells->isEmpty()) {
+            return 0;
+        }
+
+        $affectedCount = (int)floor(count($dominionIds) * self::SPECIAL_SPELL_RATIO);
+
+        if ($affectedCount === 0) {
+            return 0;
+        }
+
+        $now = now();
+        $rows = [];
+
+        for ($i = 0; $i < $affectedCount; $i++) {
+            $spell = $spells[$i % $spells->count()];
+
+            $rows[] = [
+                'dominion_id' => $dominionIds[$i],
+                'spell_id' => $spell->id,
+                'duration' => 6,
+                'cast_by_dominion_id' => $dominionIds[$i],
+                'created_at' => $now,
+                'updated_at' => $now,
+            ];
+        }
+
+        DB::table('dominion_spells')->insert($rows);
+
+        return $affectedCount;
     }
 
     /**

--- a/tests/Benchmark/Support/BenchmarkRoundSeeder.php
+++ b/tests/Benchmark/Support/BenchmarkRoundSeeder.php
@@ -1,0 +1,370 @@
+<?php
+
+namespace OpenDominion\Tests\Benchmark\Support;
+
+use Carbon\Carbon;
+use DB;
+use Illuminate\Support\Collection;
+use OpenDominion\Factories\DominionFactory;
+use OpenDominion\Factories\RealmFactory;
+use OpenDominion\Models\Dominion;
+use OpenDominion\Models\Race;
+use OpenDominion\Models\Realm;
+use OpenDominion\Models\Round;
+use OpenDominion\Models\Spell;
+use OpenDominion\Models\User;
+use OpenDominion\Services\Dominion\TickService;
+use RuntimeException;
+
+/**
+ * Builds a round with N dominions carrying enough state that every branch of the
+ * tick does real work.
+ *
+ * Deliberate choices, and what they cost in fidelity:
+ *
+ *  - Dominions are created with DominionFactory::createNonPlayer inside
+ *    Dominion::withoutEvents(). The DominionSaved listener runs a full networth
+ *    calculation plus a precalculateTick on every save, which would make seeding
+ *    N dominions cost more than the tick we are measuring.
+ *  - Users are attached to a fraction of the dominions afterwards rather than
+ *    created through the player factory. NotificationService::sendNotifications
+ *    early-returns for user-less dominions, so a bot-only fixture would not
+ *    measure the notification path at all. Production is roughly 20% players.
+ *  - mt_srand fixes every structural property of the fixture, so query counts
+ *    are reproducible. See withDeterministicRandomness() for what deliberately
+ *    stays random and why.
+ */
+final class BenchmarkRoundSeeder
+{
+    public const REALM_SIZE = 12;
+
+    public const RANDOM_SEED = 20260811;
+
+    private const PLAYER_RATIO = 0.2;
+
+    /**
+     * Queue rows written for every dominion, on top of the training rows
+     * createNonPlayer already writes.
+     *
+     * Hours are chosen so a single tick exercises both halves of the queue
+     * handling: rows at hours = 1 decrement to 0 and drive cleanupQueues plus its
+     * notifications, rows at hours = 2 decrement to 1 and are read by
+     * precalculateTick as next hour's incoming resources.
+     *
+     * No training row for military_unit2 or military_unit3 may sit in hours 4-9:
+     * createNonPlayer (DominionFactory.php:626) already queues those, and
+     * dominion_queue is keyed on (dominion_id, source, resource, hours).
+     *
+     * @var array<int, array{0: string, 1: string, 2: int, 3: int}>
+     */
+    private const QUEUE_ROWS = [
+        ['construction', 'building_home', 1, 25],
+        ['construction', 'building_farm', 2, 15],
+        ['construction', 'building_lumberyard', 9, 10],
+        ['exploration', 'land_plain', 1, 12],
+        ['exploration', 'land_forest', 2, 8],
+        ['exploration', 'land_hill', 6, 9],
+        ['training', 'military_unit1', 1, 40],
+        ['training', 'military_unit2', 2, 60],
+        ['training', 'military_unit3', 3, 20],
+        ['training', 'military_draftees', 11, 5],
+        ['invasion', 'military_unit1', 1, 30],
+        ['invasion', 'military_unit2', 5, 45],
+    ];
+
+    /**
+     * Spells createNonPlayer already casts on every dominion - picking either
+     * again would collide on the (dominion_id, spell_id) primary key.
+     *
+     * @var array<int, string>
+     */
+    private const FACTORY_SEEDED_SPELL_KEYS = ['ares_call', 'midas_touch'];
+
+    /**
+     * Durations assigned to the beneficial and harmful spells picked below.
+     *
+     * A duration of 1 decrements to 0 and drives cleanupActiveSpells (and the
+     * lazy ->spell N+1 in finding 2.2); a duration of 2 decrements to 1 and is
+     * picked up by the expiring-spells select.
+     *
+     * @var array<int, int>
+     */
+    private const BENEFICIAL_DURATIONS = [1, 2, 6, 10];
+
+    /** @var array<int, int> */
+    private const HARMFUL_DURATIONS = [1, 8];
+
+    public function __construct(
+        private readonly DominionFactory $dominionFactory,
+        private readonly RealmFactory $realmFactory,
+        private readonly TickService $tickService,
+    ) {
+    }
+
+    public function seed(int $dominionCount): BenchmarkRound
+    {
+        if ($dominionCount < 1) {
+            throw new RuntimeException('Benchmark fixtures need at least one dominion.');
+        }
+
+        return $this->withDeterministicRandomness(function () use ($dominionCount): BenchmarkRound {
+            $round = $this->createRound();
+            $races = $this->racesByAlignment();
+
+            $dominionIds = [];
+            $realmCount = 0;
+
+            while (count($dominionIds) < $dominionCount) {
+                $alignment = ($realmCount % 2 === 0) ? 'good' : 'evil';
+                $realm = $this->realmFactory->create($round, $alignment);
+                $realmCount++;
+
+                $remaining = $dominionCount - count($dominionIds);
+                $inThisRealm = min(self::REALM_SIZE, $remaining);
+
+                for ($i = 0; $i < $inThisRealm; $i++) {
+                    $dominionIds[] = $this->createDominion($realm, $races[$alignment], count($dominionIds));
+                }
+            }
+
+            $playerCount = $this->attachUsers($dominionIds);
+            $this->seedQueues($dominionIds);
+            $this->seedSpells($dominionIds);
+
+            $this->precalculate($dominionIds);
+
+            return new BenchmarkRound(
+                $round->fresh(),
+                $dominionIds,
+                $realmCount,
+                $playerCount,
+                DB::table('dominion_queue')->whereIn('dominion_id', $dominionIds)->count(),
+                DB::table('dominion_spells')->whereIn('dominion_id', $dominionIds)->count()
+            );
+        });
+    }
+
+    private function createRound(): Round
+    {
+        return Round::create([
+            'round_league_id' => 1,
+            'number' => 1,
+            'name' => 'Benchmark Round',
+            'start_date' => new Carbon('-7 days'),
+            'end_date' => new Carbon('+40 days'),
+            'pack_size' => 6,
+            'mixed_alignment' => false,
+        ]);
+    }
+
+    /**
+     * @return array<string, Collection<int, Race>>
+     */
+    private function racesByAlignment(): array
+    {
+        $races = Race::with(['perks', 'units.perks'])
+            ->where('playable', true)
+            ->orderBy('id')
+            ->get();
+
+        $byAlignment = [
+            'good' => $races->where('alignment', 'good')->values(),
+            'evil' => $races->where('alignment', 'evil')->values(),
+        ];
+
+        foreach ($byAlignment as $alignment => $collection) {
+            if ($collection->isEmpty()) {
+                throw new RuntimeException("No playable {$alignment} races found - is the database seeded?");
+            }
+        }
+
+        return $byAlignment;
+    }
+
+    /**
+     * @param Collection<int, Race> $races
+     */
+    private function createDominion(Realm $realm, Collection $races, int $index): int
+    {
+        $race = $races[$index % $races->count()];
+        $landSize = 450 + mt_rand(0, 150);
+
+        $dominion = Dominion::withoutEvents(fn (): ?Dominion => $this->dominionFactory->createNonPlayer(
+            $realm,
+            $race,
+            sprintf('Bench Ruler %d', $index),
+            sprintf('Bench Dominion %d', $index),
+            $landSize
+        ));
+
+        if ($dominion === null) {
+            throw new RuntimeException("Failed to create benchmark dominion {$index}.");
+        }
+
+        return $dominion->id;
+    }
+
+    /**
+     * Gives PLAYER_RATIO of the dominions a user so the notification path is
+     * measured rather than skipped.
+     *
+     * @param array<int, int> $dominionIds
+     */
+    private function attachUsers(array $dominionIds): int
+    {
+        $playerCount = max(1, (int)round(count($dominionIds) * self::PLAYER_RATIO));
+
+        for ($i = 0; $i < $playerCount; $i++) {
+            $user = User::factory()->create();
+
+            DB::table('dominions')
+                ->where('id', $dominionIds[$i])
+                ->update(['user_id' => $user->id]);
+        }
+
+        return $playerCount;
+    }
+
+    /**
+     * @param array<int, int> $dominionIds
+     */
+    private function seedQueues(array $dominionIds): void
+    {
+        $now = now();
+        $rows = [];
+
+        foreach ($dominionIds as $dominionId) {
+            foreach (self::QUEUE_ROWS as [$source, $resource, $hours, $amount]) {
+                $rows[] = [
+                    'dominion_id' => $dominionId,
+                    'source' => $source,
+                    'resource' => $resource,
+                    'hours' => $hours,
+                    'amount' => $amount,
+                    'created_at' => $now,
+                    'updated_at' => $now,
+                ];
+            }
+        }
+
+        foreach (array_chunk($rows, 500) as $chunk) {
+            DB::table('dominion_queue')->insert($chunk);
+        }
+    }
+
+    /**
+     * @param array<int, int> $dominionIds
+     */
+    private function seedSpells(array $dominionIds): void
+    {
+        [$beneficial, $harmful] = $this->pickSpells();
+
+        $now = now();
+        $rows = [];
+
+        foreach ($dominionIds as $dominionId) {
+            foreach ($beneficial as $offset => $spell) {
+                $rows[] = [
+                    'dominion_id' => $dominionId,
+                    'spell_id' => $spell->id,
+                    'duration' => self::BENEFICIAL_DURATIONS[$offset],
+                    'cast_by_dominion_id' => $dominionId,
+                    'created_at' => $now,
+                    'updated_at' => $now,
+                ];
+            }
+
+            foreach ($harmful as $offset => $spell) {
+                $rows[] = [
+                    'dominion_id' => $dominionId,
+                    'spell_id' => $spell->id,
+                    'duration' => self::HARMFUL_DURATIONS[$offset],
+                    'cast_by_dominion_id' => $dominionId,
+                    'created_at' => $now,
+                    'updated_at' => $now,
+                ];
+            }
+        }
+
+        foreach (array_chunk($rows, 500) as $chunk) {
+            DB::table('dominion_spells')->insert($chunk);
+        }
+    }
+
+    /**
+     * Prefers the spells carrying the most perks - the perk fan-out in finding
+     * 2.3 is proportional to perk count, so the cheapest spells would understate
+     * it.
+     *
+     * @return array{0: Collection<int, Spell>, 1: Collection<int, Spell>}
+     */
+    private function pickSpells(): array
+    {
+        $spells = Spell::withCount('perks')
+            ->orderByDesc('perks_count')
+            ->orderBy('id')
+            ->get();
+
+        $spells = $spells->reject(
+            fn (Spell $spell): bool => in_array($spell->key, self::FACTORY_SEEDED_SPELL_KEYS, true)
+        );
+
+        $beneficial = $spells->reject(fn (Spell $spell): bool => $spell->isHarmful())
+            ->take(count(self::BENEFICIAL_DURATIONS))
+            ->values();
+
+        $harmful = $spells->filter(fn (Spell $spell): bool => $spell->isHarmful())
+            ->take(count(self::HARMFUL_DURATIONS))
+            ->values();
+
+        if ($beneficial->count() < count(self::BENEFICIAL_DURATIONS) || $harmful->count() < count(self::HARMFUL_DURATIONS)) {
+            throw new RuntimeException('Not enough spells in the database to build the benchmark fixture.');
+        }
+
+        return [$beneficial, $harmful];
+    }
+
+    /**
+     * Establishes the dominion_tick rows that phase A of the tick joins against.
+     * Without this the bulk update matches nothing and the measurement is
+     * meaningless.
+     *
+     * @param array<int, int> $dominionIds
+     */
+    private function precalculate(array $dominionIds): void
+    {
+        $dominions = Dominion::whereIn('id', $dominionIds)
+            ->with(['queues', 'spells', 'techs', 'race.units.perks', 'race.perks'])
+            ->get();
+
+        foreach ($dominions as $dominion) {
+            $this->tickService->precalculateTick($dominion);
+        }
+    }
+
+    /**
+     * Seeds mt_rand, which fixes every structural property the benchmark
+     * measures: the number of realms, dominions, queue rows and spell rows.
+     *
+     * createNonPlayer also calls random_chance(), which is backed by random_int
+     * and cannot be seeded. That is left alone on purpose. It varies unit counts
+     * and building mix - realistic dominion variety - but not row counts, so
+     * query counts stay reproducible while wall time wobbles slightly. Pinning it
+     * through the codebase's $mockRandomChance global would force every dominion
+     * to zero elites and zero factories, which is a worse fixture.
+     *
+     * @template T
+     * @param callable(): T $callback
+     * @return T
+     */
+    private function withDeterministicRandomness(callable $callback)
+    {
+        mt_srand(self::RANDOM_SEED);
+
+        try {
+            return $callback();
+        } finally {
+            mt_srand();
+        }
+    }
+}

--- a/tests/Benchmark/Support/TickProfile.php
+++ b/tests/Benchmark/Support/TickProfile.php
@@ -1,0 +1,292 @@
+<?php
+
+namespace OpenDominion\Tests\Benchmark\Support;
+
+/**
+ * Immutable result of a single profiled run.
+ *
+ * Query count is the primary metric: it is deterministic across machines and
+ * maps directly onto the findings in firstroundfindings.txt / secondroundfindings.txt.
+ * Timings are recorded for reporting only - never assert on them.
+ *
+ * @phpstan-type QueryRecord array{sql: string, bindings: array, time: float}
+ */
+final class TickProfile
+{
+    /**
+     * @param array<int, array{sql: string, bindings: array, time: float}> $queries
+     */
+    public function __construct(
+        private readonly string $label,
+        private readonly array $queries,
+        private readonly float $wallTimeMs,
+        private readonly int $memoryDeltaBytes,
+        private readonly int $peakMemoryBytes,
+        private readonly ?int $dominionCount = null,
+    ) {
+    }
+
+    public function label(): string
+    {
+        return $this->label;
+    }
+
+    public function dominionCount(): ?int
+    {
+        return $this->dominionCount;
+    }
+
+    public function queryCount(): int
+    {
+        return count($this->queries);
+    }
+
+    public function wallTimeMs(): float
+    {
+        return $this->wallTimeMs;
+    }
+
+    /**
+     * Sum of the database's own reported execution time. Always less than
+     * wallTimeMs(); the difference is PHP-side compute.
+     */
+    public function queryTimeMs(): float
+    {
+        return array_sum(array_column($this->queries, 'time'));
+    }
+
+    /**
+     * Time spent outside the database driver - the calculator and perk-rebuild
+     * cost that findings 2.3 / 2.4 / M2 are about.
+     */
+    public function computeTimeMs(): float
+    {
+        return max(0.0, $this->wallTimeMs - $this->queryTimeMs());
+    }
+
+    public function memoryDeltaBytes(): int
+    {
+        return $this->memoryDeltaBytes;
+    }
+
+    /**
+     * Process-wide peak, not a delta - memory_get_peak_usage() is monotonic, so
+     * this is only comparable between runs in the same process and only ratchets
+     * upwards.
+     */
+    public function peakMemoryBytes(): int
+    {
+        return $this->peakMemoryBytes;
+    }
+
+    public function queriesPerDominion(): ?float
+    {
+        if ($this->dominionCount === null || $this->dominionCount === 0) {
+            return null;
+        }
+
+        return $this->queryCount() / $this->dominionCount;
+    }
+
+    /**
+     * Query counts attributed to the primary (first-mentioned) table of each
+     * statement, ordered by count descending.
+     *
+     * @return array<string, int>
+     */
+    public function queryCountsByTable(): array
+    {
+        $counts = [];
+
+        foreach ($this->queries as $query) {
+            $table = $this->primaryTable($query['sql']) ?? '(unknown)';
+            $counts[$table] = ($counts[$table] ?? 0) + 1;
+        }
+
+        arsort($counts);
+
+        return $counts;
+    }
+
+    /**
+     * Number of statements whose SQL contains the given fragment, matched
+     * case-insensitively. Use for targeted budgets, e.g. countMatching('dominion_spells').
+     */
+    public function countMatching(string $fragment): int
+    {
+        $matches = 0;
+
+        foreach ($this->queries as $query) {
+            if (stripos($query['sql'], $fragment) !== false) {
+                $matches++;
+            }
+        }
+
+        return $matches;
+    }
+
+    /**
+     * Statements executed more than once, keyed by normalized SQL and ordered by
+     * execution count descending. This is the N+1 detector: a statement repeated
+     * once per dominion (or once per row) shows up at the top.
+     *
+     * @return array<string, int>
+     */
+    public function duplicateGroups(int $minimumCount = 2): array
+    {
+        $groups = [];
+
+        foreach ($this->queries as $query) {
+            $normalized = $this->normalize($query['sql']);
+            $groups[$normalized] = ($groups[$normalized] ?? 0) + 1;
+        }
+
+        $groups = array_filter($groups, static fn (int $count): bool => $count >= $minimumCount);
+
+        arsort($groups);
+
+        return $groups;
+    }
+
+    /**
+     * The slowest statements by total accumulated time, keyed by normalized SQL.
+     *
+     * @return array<string, array{count: int, totalMs: float}>
+     */
+    public function slowestGroups(int $limit = 10): array
+    {
+        $groups = [];
+
+        foreach ($this->queries as $query) {
+            $normalized = $this->normalize($query['sql']);
+
+            if (!isset($groups[$normalized])) {
+                $groups[$normalized] = ['count' => 0, 'totalMs' => 0.0];
+            }
+
+            $groups[$normalized]['count']++;
+            $groups[$normalized]['totalMs'] += $query['time'];
+        }
+
+        uasort($groups, static fn (array $a, array $b): int => $b['totalMs'] <=> $a['totalMs']);
+
+        return array_slice($groups, 0, $limit, true);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'label' => $this->label,
+            'dominions' => $this->dominionCount,
+            'queries' => $this->queryCount(),
+            'queriesPerDominion' => $this->queriesPerDominion(),
+            'wallTimeMs' => round($this->wallTimeMs, 2),
+            'queryTimeMs' => round($this->queryTimeMs(), 2),
+            'computeTimeMs' => round($this->computeTimeMs(), 2),
+            'memoryDeltaMb' => round($this->memoryDeltaBytes / 1048576, 2),
+            'peakMemoryMb' => round($this->peakMemoryBytes / 1048576, 2),
+            'byTable' => $this->queryCountsByTable(),
+            'duplicates' => $this->duplicateGroups(),
+        ];
+    }
+
+    /**
+     * Human-readable report block, written to STDERR by the baseline test.
+     */
+    public function render(int $duplicateLimit = 12): string
+    {
+        $lines = [];
+
+        $lines[] = str_repeat('=', 78);
+        $lines[] = sprintf('%s%s', $this->label, $this->dominionCount !== null ? "  (N = {$this->dominionCount})" : '');
+        $lines[] = str_repeat('=', 78);
+
+        $perDominion = $this->queriesPerDominion();
+
+        $lines[] = sprintf('  queries          %d%s', $this->queryCount(), $perDominion !== null
+            ? sprintf('   (%.2f per dominion)', $perDominion)
+            : '');
+        $lines[] = sprintf('  wall time        %.1f ms', $this->wallTimeMs);
+        $lines[] = sprintf('  in database      %.1f ms (%.0f%%)', $this->queryTimeMs(), $this->percentageOfWall($this->queryTimeMs()));
+        $lines[] = sprintf('  in php           %.1f ms (%.0f%%)', $this->computeTimeMs(), $this->percentageOfWall($this->computeTimeMs()));
+        $lines[] = sprintf('  memory delta     %.1f MB (process peak %.1f MB)', $this->memoryDeltaBytes / 1048576, $this->peakMemoryBytes / 1048576);
+
+        $lines[] = '';
+        $lines[] = '  queries by table';
+
+        foreach ($this->queryCountsByTable() as $table => $count) {
+            $lines[] = sprintf('    %-32s %6d%s', $table, $count, $perDominion !== null
+                ? sprintf('  (%.2f/dom)', $count / $this->dominionCount)
+                : '');
+        }
+
+        $duplicates = $this->duplicateGroups();
+
+        if ($duplicates !== []) {
+            $lines[] = '';
+            $lines[] = sprintf('  repeated statements (top %d) - N+1 candidates', $duplicateLimit);
+
+            foreach (array_slice($duplicates, 0, $duplicateLimit, true) as $sql => $count) {
+                $lines[] = sprintf('    %6dx  %s', $count, $this->truncate($sql, 96));
+            }
+        }
+
+        $lines[] = '';
+        $lines[] = '  slowest statements by total time';
+
+        foreach ($this->slowestGroups(8) as $sql => $stats) {
+            $lines[] = sprintf(
+                '    %8.1f ms  %5dx  %s',
+                $stats['totalMs'],
+                $stats['count'],
+                $this->truncate($sql, 84)
+            );
+        }
+
+        $lines[] = '';
+
+        return implode(PHP_EOL, $lines) . PHP_EOL;
+    }
+
+    private function percentageOfWall(float $milliseconds): float
+    {
+        if ($this->wallTimeMs <= 0.0) {
+            return 0.0;
+        }
+
+        return ($milliseconds / $this->wallTimeMs) * 100;
+    }
+
+    /**
+     * Collapses bind-list width and whitespace so the same logical statement
+     * groups together regardless of how many ids it was called with.
+     */
+    private function normalize(string $sql): string
+    {
+        $sql = preg_replace('/\s+/', ' ', trim($sql));
+        $sql = preg_replace('/\(\s*\?(?:\s*,\s*\?)*\s*\)/', '(?)', $sql);
+
+        return $sql;
+    }
+
+    private function primaryTable(string $sql): ?string
+    {
+        if (preg_match('/\b(?:from|into|update|join)\s+`?([a-zA-Z0-9_]+)`?/i', $sql, $matches) === 1) {
+            return $matches[1];
+        }
+
+        return null;
+    }
+
+    private function truncate(string $value, int $length): string
+    {
+        if (strlen($value) <= $length) {
+            return $value;
+        }
+
+        return substr($value, 0, $length - 3) . '...';
+    }
+}

--- a/tests/Benchmark/Support/TickProfile.php
+++ b/tests/Benchmark/Support/TickProfile.php
@@ -2,6 +2,8 @@
 
 namespace OpenDominion\Tests\Benchmark\Support;
 
+use OpenDominion\Services\QueryProfilerService;
+
 /**
  * Immutable result of a single profiled run.
  *
@@ -320,24 +322,17 @@ final class TickProfile
     }
 
     /**
-     * Collapses bind-list width and whitespace so the same logical statement
-     * groups together regardless of how many ids it was called with.
+     * Delegated to the shared service so test-scale and real-scale reports group
+     * and attribute statements identically.
      */
     private function normalize(string $sql): string
     {
-        $sql = preg_replace('/\s+/', ' ', trim($sql));
-        $sql = preg_replace('/\(\s*\?(?:\s*,\s*\?)*\s*\)/', '(?)', $sql);
-
-        return $sql;
+        return QueryProfilerService::normalize($sql);
     }
 
     private function primaryTable(string $sql): ?string
     {
-        if (preg_match('/\b(?:from|into|update|join)\s+`?([a-zA-Z0-9_]+)`?/i', $sql, $matches) === 1) {
-            return $matches[1];
-        }
-
-        return null;
+        return QueryProfilerService::primaryTable($sql);
     }
 
     private function truncate(string $value, int $length): string

--- a/tests/Benchmark/Support/TickProfile.php
+++ b/tests/Benchmark/Support/TickProfile.php
@@ -126,6 +126,65 @@ final class TickProfile
     }
 
     /**
+     * Number of statements whose SQL matches the given regex. Used to isolate a
+     * specific phase, e.g. the three bulk join-updates of phase A.
+     */
+    public function countMatchingPattern(string $pattern): int
+    {
+        $matches = 0;
+
+        foreach ($this->queries as $query) {
+            if (preg_match($pattern, $this->normalize($query['sql'])) === 1) {
+                $matches++;
+            }
+        }
+
+        return $matches;
+    }
+
+    /**
+     * The normalized statements matching a regex, keyed by SQL and counted.
+     * Exists so a failing budget can show what it actually saw.
+     *
+     * @return array<string, int>
+     */
+    public function statementsMatching(string $pattern): array
+    {
+        $found = [];
+
+        foreach ($this->queries as $query) {
+            $normalized = $this->normalize($query['sql']);
+
+            if (preg_match($pattern, $normalized) === 1) {
+                $found[$normalized] = ($found[$normalized] ?? 0) + 1;
+            }
+        }
+
+        arsort($found);
+
+        return $found;
+    }
+
+    /**
+     * The single most-repeated statement, as [sql, count]. Null when nothing ran
+     * more than once.
+     *
+     * @return array{0: string, 1: int}|null
+     */
+    public function mostRepeatedStatement(): ?array
+    {
+        $groups = $this->duplicateGroups();
+
+        if ($groups === []) {
+            return null;
+        }
+
+        $sql = array_key_first($groups);
+
+        return [$sql, $groups[$sql]];
+    }
+
+    /**
      * Statements executed more than once, keyed by normalized SQL and ordered by
      * execution count descending. This is the N+1 detector: a statement repeated
      * once per dominion (or once per row) shows up at the top.

--- a/tests/Benchmark/Support/TickProfiler.php
+++ b/tests/Benchmark/Support/TickProfiler.php
@@ -2,93 +2,61 @@
 
 namespace OpenDominion\Tests\Benchmark\Support;
 
-use DB;
-use Illuminate\Database\Events\QueryExecuted;
+use OpenDominion\Services\QueryProfilerService;
 
 /**
- * Records query counts, timings and memory for a callback.
+ * Adds timing, memory and TickProfile construction on top of the shared
+ * QueryProfilerService.
  *
- * A single listener is attached lazily and gated by a recording flag, because
- * Laravel offers no way to detach a DB::listen callback - registering one per
- * measurement would double-count every subsequent run.
+ * Query capture and SQL normalization deliberately live in the service rather
+ * than here, so the benchmark suite and dev:tick:profile measure the same thing
+ * the same way and their numbers can be compared directly.
  */
 final class TickProfiler
 {
-    private bool $listening = false;
+    private QueryProfilerService $recorder;
 
-    private bool $recording = false;
-
-    /** @var array<int, array{sql: string, bindings: array, time: float}> */
-    private array $queries = [];
+    public function __construct(?QueryProfilerService $recorder = null)
+    {
+        $this->recorder = $recorder ?? new QueryProfilerService();
+    }
 
     /**
      * Runs a callback without recording it.
      *
      * Always warm up before measuring. The container binds every calculator as a
      * singleton, Race::findWithRelationsCached and Round::findCached populate the
-     * array cache on first touch, and PHP resolves autoloads lazily - none of
-     * which are per-tick costs in production, where the process is long-lived.
+     * cache on first touch, and PHP resolves autoloads lazily - none of which are
+     * per-tick costs in a long-lived production process.
      */
     public function warmUp(callable $callback): void
     {
-        $wasRecording = $this->recording;
-        $this->recording = false;
-
-        try {
-            $callback();
-        } finally {
-            $this->recording = $wasRecording;
-        }
+        $this->recorder->withoutRecording($callback);
     }
 
     public function profile(string $label, callable $callback, ?int $dominionCount = null): TickProfile
     {
-        $this->attachListener();
-
-        $this->queries = [];
-
         gc_collect_cycles();
 
         $memoryBefore = memory_get_usage(true);
         $startedAt = hrtime(true);
 
-        $this->recording = true;
+        $this->recorder->start();
 
         try {
             $callback();
         } finally {
             $wallTimeMs = (hrtime(true) - $startedAt) / 1000000;
-            $this->recording = false;
+            $queries = $this->recorder->stop();
         }
 
         return new TickProfile(
             $label,
-            $this->queries,
+            $queries,
             $wallTimeMs,
             memory_get_usage(true) - $memoryBefore,
             memory_get_peak_usage(true),
             $dominionCount
         );
-    }
-
-    private function attachListener(): void
-    {
-        if ($this->listening) {
-            return;
-        }
-
-        DB::listen(function (QueryExecuted $query): void {
-            if (!$this->recording) {
-                return;
-            }
-
-            $this->queries[] = [
-                'sql' => $query->sql,
-                'bindings' => $query->bindings,
-                'time' => (float)$query->time,
-            ];
-        });
-
-        $this->listening = true;
     }
 }

--- a/tests/Benchmark/Support/TickProfiler.php
+++ b/tests/Benchmark/Support/TickProfiler.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace OpenDominion\Tests\Benchmark\Support;
+
+use DB;
+use Illuminate\Database\Events\QueryExecuted;
+
+/**
+ * Records query counts, timings and memory for a callback.
+ *
+ * A single listener is attached lazily and gated by a recording flag, because
+ * Laravel offers no way to detach a DB::listen callback - registering one per
+ * measurement would double-count every subsequent run.
+ */
+final class TickProfiler
+{
+    private bool $listening = false;
+
+    private bool $recording = false;
+
+    /** @var array<int, array{sql: string, bindings: array, time: float}> */
+    private array $queries = [];
+
+    /**
+     * Runs a callback without recording it.
+     *
+     * Always warm up before measuring. The container binds every calculator as a
+     * singleton, Race::findWithRelationsCached and Round::findCached populate the
+     * array cache on first touch, and PHP resolves autoloads lazily - none of
+     * which are per-tick costs in production, where the process is long-lived.
+     */
+    public function warmUp(callable $callback): void
+    {
+        $wasRecording = $this->recording;
+        $this->recording = false;
+
+        try {
+            $callback();
+        } finally {
+            $this->recording = $wasRecording;
+        }
+    }
+
+    public function profile(string $label, callable $callback, ?int $dominionCount = null): TickProfile
+    {
+        $this->attachListener();
+
+        $this->queries = [];
+
+        gc_collect_cycles();
+
+        $memoryBefore = memory_get_usage(true);
+        $startedAt = hrtime(true);
+
+        $this->recording = true;
+
+        try {
+            $callback();
+        } finally {
+            $wallTimeMs = (hrtime(true) - $startedAt) / 1000000;
+            $this->recording = false;
+        }
+
+        return new TickProfile(
+            $label,
+            $this->queries,
+            $wallTimeMs,
+            memory_get_usage(true) - $memoryBefore,
+            memory_get_peak_usage(true),
+            $dominionCount
+        );
+    }
+
+    private function attachListener(): void
+    {
+        if ($this->listening) {
+            return;
+        }
+
+        DB::listen(function (QueryExecuted $query): void {
+            if (!$this->recording) {
+                return;
+            }
+
+            $this->queries[] = [
+                'sql' => $query->sql,
+                'bindings' => $query->bindings,
+                'time' => (float)$query->time,
+            ];
+        });
+
+        $this->listening = true;
+    }
+}

--- a/tests/Benchmark/TickBaselineReportTest.php
+++ b/tests/Benchmark/TickBaselineReportTest.php
@@ -1,0 +1,254 @@
+<?php
+
+namespace OpenDominion\Tests\Benchmark;
+
+use OpenDominion\Factories\DominionFactory;
+use OpenDominion\Factories\RealmFactory;
+use OpenDominion\Models\Dominion;
+use OpenDominion\Models\Race;
+use OpenDominion\Models\Round;
+use OpenDominion\Services\Dominion\TickService;
+use OpenDominion\Tests\AbstractTestCase;
+use OpenDominion\Tests\Benchmark\Support\BenchmarkRound;
+use OpenDominion\Tests\Benchmark\Support\BenchmarkRoundSeeder;
+use OpenDominion\Tests\Benchmark\Support\TickProfile;
+use OpenDominion\Tests\Benchmark\Support\TickProfiler;
+use PHPUnit\Framework\Attributes\Group;
+
+/**
+ * Phase 0 of the tick benchmarking work: measure, do not judge.
+ *
+ * This class has no budgets. Its job is to turn the call-graph arithmetic in
+ * firstroundfindings.txt and secondroundfindings.txt into numbers from a real
+ * database, so that phase 1 can freeze those numbers as hard budgets.
+ *
+ * Run with:
+ *   php artisan test --group=benchmark
+ *   BENCH_REPORT=1 php artisan test --group=benchmark   (also writes JSON)
+ *
+ * Caveats that apply to every number below:
+ *
+ *  - AbstractTestCase uses DatabaseTransactions, so the tick's own
+ *    DB::transaction calls degrade to savepoints. Commit cost and lock
+ *    contention are NOT measured; finding 5.2 needs a real-scale profile run.
+ *  - Wall time is machine-dependent and should never be asserted on. Query
+ *    counts are what phase 1 will ratchet.
+ *  - N here is 10 and 40. Production is in the thousands. Linear behaviour is
+ *    established by the slope between the two, not by absolute magnitude.
+ */
+#[Group('benchmark')]
+class TickBaselineReportTest extends AbstractTestCase
+{
+    private const SMALL_N = 10;
+
+    private const LARGE_N = 40;
+
+    private TickProfiler $profiler;
+
+    private BenchmarkRoundSeeder $seeder;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->profiler = new TickProfiler();
+        $this->seeder = new BenchmarkRoundSeeder(
+            $this->app->make(DominionFactory::class),
+            $this->app->make(RealmFactory::class),
+            $this->app->make(TickService::class),
+        );
+    }
+
+    /**
+     * Isolates the two single-dominion entry points.
+     *
+     * precalculateTick is the ~20-queries-per-dominion claim in finding 2.1;
+     * measuring it alone separates it from cleanup and notifications, which the
+     * production Log::info at TickService.php:436 lumps together.
+     */
+    public function testReportSingleDominionBaseline(): void
+    {
+        $fixture = $this->seeder->seed(1);
+        $tickService = $this->app->make(TickService::class);
+        $dominion = Dominion::findOrFail($fixture->dominionIds[0]);
+
+        $this->warmUp($fixture);
+
+
+        $precalculate = $this->profiler->profile(
+            'precalculateTick() - one dominion',
+            static function () use ($tickService, $dominion): void {
+                $tickService->precalculateTick($dominion);
+            },
+            1
+        );
+
+        $singleTick = $this->profiler->profile(
+            'performTick($round, $dominion) - single dominion path',
+            static function () use ($tickService, $fixture, $dominion): void {
+                $tickService->performTick($fixture->round, $dominion);
+            },
+            1
+        );
+
+        $this->report($fixture, [$precalculate, $singleTick]);
+
+        $this->assertGreaterThan(0, $precalculate->queryCount());
+    }
+
+    /**
+     * The scaling measurement. Two independent rounds are seeded so the same
+     * process ticks both; the marginal cost between them is the per-dominion
+     * slope that phase 1 will budget against.
+     */
+    public function testReportRoundBaselineAcrossDominionCounts(): void
+    {
+        $small = $this->seeder->seed(self::SMALL_N);
+        $large = $this->seeder->seed(self::LARGE_N);
+
+        $tickService = $this->app->make(TickService::class);
+
+        $this->warmUp($small, $large);
+
+        $smallProfile = $this->profiler->profile(
+            sprintf('performTick($round) - whole round, N = %d', self::SMALL_N),
+            static function () use ($tickService, $small): void {
+                $tickService->performTick($small->round);
+            },
+            self::SMALL_N
+        );
+
+        $largeProfile = $this->profiler->profile(
+            sprintf('performTick($round) - whole round, N = %d', self::LARGE_N),
+            static function () use ($tickService, $large): void {
+                $tickService->performTick($large->round);
+            },
+            self::LARGE_N
+        );
+
+        $this->report($small, [$smallProfile]);
+        $this->report($large, [$largeProfile]);
+        $this->reportSlope($smallProfile, $largeProfile);
+
+        $this->assertGreaterThan(0, $largeProfile->queryCount());
+    }
+
+    /**
+     * Excludes one-off setup from the measurement: container singletons,
+     * autoloading, opcache, and the two rememberForever caches the tick reads
+     * through - Race::findWithRelationsCached and Round::findCached.
+     *
+     * EVERY fixture that will be measured has to be warmed, not just the first.
+     * The race cache is keyed per race id, so a larger round touches races a
+     * smaller one never did; leaving those cold would charge the larger run for
+     * cache population and fake a superlinear slope.
+     *
+     * What this deliberately hides: roughly one query per distinct race plus one
+     * per round. That is fixed reference-data cost, not per-dominion cost, and
+     * whether production pays it hourly depends on its cache driver.
+     *
+     * precalculateTick is deterministic, so re-running it on an already-seeded
+     * dominion leaves the fixture unchanged.
+     */
+    private function warmUp(BenchmarkRound ...$fixtures): void
+    {
+        $tickService = $this->app->make(TickService::class);
+
+        foreach ($fixtures as $fixture) {
+            $raceIds = Dominion::whereIn('id', $fixture->dominionIds)
+                ->distinct()
+                ->pluck('race_id');
+
+            $dominion = Dominion::findOrFail($fixture->dominionIds[0]);
+
+            $this->profiler->warmUp(static function () use ($tickService, $fixture, $raceIds, $dominion): void {
+                Round::findCached($fixture->round->id);
+
+                foreach ($raceIds as $raceId) {
+                    Race::findWithRelationsCached($raceId);
+                }
+
+                $tickService->precalculateTick($dominion);
+            });
+        }
+    }
+
+    /**
+     * @param array<int, TickProfile> $profiles
+     */
+    private function report(BenchmarkRound $fixture, array $profiles): void
+    {
+        $this->write(PHP_EOL . 'fixture: ' . $fixture->describe() . PHP_EOL);
+
+        foreach ($profiles as $profile) {
+            $this->write($profile->render());
+            $this->writeJson($profile);
+        }
+    }
+
+    /**
+     * The number phase 1 cares about: how many queries each additional dominion
+     * costs, isolated from the round's fixed overhead.
+     */
+    private function reportSlope(TickProfile $small, TickProfile $large): void
+    {
+        $deltaQueries = $large->queryCount() - $small->queryCount();
+        $deltaDominions = self::LARGE_N - self::SMALL_N;
+        $marginal = $deltaQueries / $deltaDominions;
+        $fixedOverhead = $small->queryCount() - ($marginal * self::SMALL_N);
+
+        $lines = [
+            str_repeat('=', 78),
+            'SCALING',
+            str_repeat('=', 78),
+            sprintf('  N = %-4d %6d queries   (%.2f per dominion)', self::SMALL_N, $small->queryCount(), $small->queriesPerDominion()),
+            sprintf('  N = %-4d %6d queries   (%.2f per dominion)', self::LARGE_N, $large->queryCount(), $large->queriesPerDominion()),
+            '',
+            sprintf('  marginal cost    %.2f queries per additional dominion', $marginal),
+            sprintf('  fixed overhead   %.1f queries per round', $fixedOverhead),
+            '',
+            sprintf('  wall time        %.1f ms -> %.1f ms (%.2fx for %.2fx the dominions)',
+                $small->wallTimeMs(),
+                $large->wallTimeMs(),
+                $small->wallTimeMs() > 0 ? $large->wallTimeMs() / $small->wallTimeMs() : 0,
+                self::LARGE_N / self::SMALL_N
+            ),
+            '',
+            '  A marginal cost close to the per-dominion figure means linear scaling.',
+            '  A marginal cost materially above it means something is superlinear.',
+            '',
+        ];
+
+        $this->write(implode(PHP_EOL, $lines) . PHP_EOL);
+    }
+
+    /**
+     * STDERR rather than echo: PHPUnit captures test output and, depending on
+     * configuration, flags it as risky. STDERR goes straight to the terminal.
+     */
+    private function write(string $text): void
+    {
+        fwrite(STDERR, $text);
+    }
+
+    private function writeJson(TickProfile $profile): void
+    {
+        if (getenv('BENCH_REPORT') === false || getenv('BENCH_REPORT') === '') {
+            return;
+        }
+
+        $directory = storage_path('benchmarks');
+
+        if (!is_dir($directory)) {
+            mkdir($directory, 0755, true);
+        }
+
+        $filename = sprintf(
+            '%s/tick-%s.json',
+            $directory,
+            preg_replace('/[^a-z0-9]+/i', '-', strtolower($profile->label()))
+        );
+
+        file_put_contents($filename, json_encode($profile->toArray(), JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+    }
+}

--- a/tests/Benchmark/TickBaselineReportTest.php
+++ b/tests/Benchmark/TickBaselineReportTest.php
@@ -2,17 +2,9 @@
 
 namespace OpenDominion\Tests\Benchmark;
 
-use OpenDominion\Factories\DominionFactory;
-use OpenDominion\Factories\RealmFactory;
 use OpenDominion\Models\Dominion;
-use OpenDominion\Models\Race;
-use OpenDominion\Models\Round;
-use OpenDominion\Services\Dominion\TickService;
-use OpenDominion\Tests\AbstractTestCase;
 use OpenDominion\Tests\Benchmark\Support\BenchmarkRound;
-use OpenDominion\Tests\Benchmark\Support\BenchmarkRoundSeeder;
 use OpenDominion\Tests\Benchmark\Support\TickProfile;
-use OpenDominion\Tests\Benchmark\Support\TickProfiler;
 use PHPUnit\Framework\Attributes\Group;
 
 /**
@@ -37,27 +29,11 @@ use PHPUnit\Framework\Attributes\Group;
  *    established by the slope between the two, not by absolute magnitude.
  */
 #[Group('benchmark')]
-class TickBaselineReportTest extends AbstractTestCase
+class TickBaselineReportTest extends AbstractTickBenchmarkTestCase
 {
-    private const SMALL_N = 10;
+    private const SMALL_N = TickBenchmarkBudgets::SMALL_N;
 
-    private const LARGE_N = 40;
-
-    private TickProfiler $profiler;
-
-    private BenchmarkRoundSeeder $seeder;
-
-    protected function setUp(): void
-    {
-        parent::setUp();
-
-        $this->profiler = new TickProfiler();
-        $this->seeder = new BenchmarkRoundSeeder(
-            $this->app->make(DominionFactory::class),
-            $this->app->make(RealmFactory::class),
-            $this->app->make(TickService::class),
-        );
-    }
+    private const LARGE_N = TickBenchmarkBudgets::LARGE_N;
 
     /**
      * Isolates the two single-dominion entry points.
@@ -65,11 +41,18 @@ class TickBaselineReportTest extends AbstractTestCase
      * precalculateTick is the ~20-queries-per-dominion claim in finding 2.1;
      * measuring it alone separates it from cleanup and notifications, which the
      * production Log::info at TickService.php:436 lumps together.
+     *
+     * Note the ordering effect on the second profile: profiling precalculateTick
+     * first leaves the race relations hydrated on $dominion, so the performTick
+     * measurement below reports the WARM number (77 rather than 91). That is a
+     * legitimate production shape - it is what NPD generation does at
+     * TickService.php:241-242 - but the budget in TickServiceBenchmarkTest holds
+     * the cold number instead.
      */
     public function testReportSingleDominionBaseline(): void
     {
         $fixture = $this->seeder->seed(1);
-        $tickService = $this->app->make(TickService::class);
+        $tickService = $this->tickService();
         $dominion = Dominion::findOrFail($fixture->dominionIds[0]);
 
         $this->warmUp($fixture);
@@ -106,7 +89,7 @@ class TickBaselineReportTest extends AbstractTestCase
         $small = $this->seeder->seed(self::SMALL_N);
         $large = $this->seeder->seed(self::LARGE_N);
 
-        $tickService = $this->app->make(TickService::class);
+        $tickService = $this->tickService();
 
         $this->warmUp($small, $large);
 
@@ -131,46 +114,6 @@ class TickBaselineReportTest extends AbstractTestCase
         $this->reportSlope($smallProfile, $largeProfile);
 
         $this->assertGreaterThan(0, $largeProfile->queryCount());
-    }
-
-    /**
-     * Excludes one-off setup from the measurement: container singletons,
-     * autoloading, opcache, and the two rememberForever caches the tick reads
-     * through - Race::findWithRelationsCached and Round::findCached.
-     *
-     * EVERY fixture that will be measured has to be warmed, not just the first.
-     * The race cache is keyed per race id, so a larger round touches races a
-     * smaller one never did; leaving those cold would charge the larger run for
-     * cache population and fake a superlinear slope.
-     *
-     * What this deliberately hides: roughly one query per distinct race plus one
-     * per round. That is fixed reference-data cost, not per-dominion cost, and
-     * whether production pays it hourly depends on its cache driver.
-     *
-     * precalculateTick is deterministic, so re-running it on an already-seeded
-     * dominion leaves the fixture unchanged.
-     */
-    private function warmUp(BenchmarkRound ...$fixtures): void
-    {
-        $tickService = $this->app->make(TickService::class);
-
-        foreach ($fixtures as $fixture) {
-            $raceIds = Dominion::whereIn('id', $fixture->dominionIds)
-                ->distinct()
-                ->pluck('race_id');
-
-            $dominion = Dominion::findOrFail($fixture->dominionIds[0]);
-
-            $this->profiler->warmUp(static function () use ($tickService, $fixture, $raceIds, $dominion): void {
-                Round::findCached($fixture->round->id);
-
-                foreach ($raceIds as $raceId) {
-                    Race::findWithRelationsCached($raceId);
-                }
-
-                $tickService->precalculateTick($dominion);
-            });
-        }
     }
 
     /**
@@ -220,15 +163,6 @@ class TickBaselineReportTest extends AbstractTestCase
         ];
 
         $this->write(implode(PHP_EOL, $lines) . PHP_EOL);
-    }
-
-    /**
-     * STDERR rather than echo: PHPUnit captures test output and, depending on
-     * configuration, flags it as risky. STDERR goes straight to the terminal.
-     */
-    private function write(string $text): void
-    {
-        fwrite(STDERR, $text);
     }
 
     private function writeJson(TickProfile $profile): void

--- a/tests/Benchmark/TickBaselineReportTest.php
+++ b/tests/Benchmark/TickBaselineReportTest.php
@@ -57,7 +57,6 @@ class TickBaselineReportTest extends AbstractTickBenchmarkTestCase
 
         $this->warmUp($fixture);
 
-
         $precalculate = $this->profiler->profile(
             'precalculateTick() - one dominion',
             static function () use ($tickService, $dominion): void {
@@ -150,7 +149,8 @@ class TickBaselineReportTest extends AbstractTickBenchmarkTestCase
             sprintf('  marginal cost    %.2f queries per additional dominion', $marginal),
             sprintf('  fixed overhead   %.1f queries per round', $fixedOverhead),
             '',
-            sprintf('  wall time        %.1f ms -> %.1f ms (%.2fx for %.2fx the dominions)',
+            sprintf(
+                '  wall time        %.1f ms -> %.1f ms (%.2fx for %.2fx the dominions)',
                 $small->wallTimeMs(),
                 $large->wallTimeMs(),
                 $small->wallTimeMs() > 0 ? $large->wallTimeMs() / $small->wallTimeMs() : 0,

--- a/tests/Benchmark/TickBenchmarkBudgets.php
+++ b/tests/Benchmark/TickBenchmarkBudgets.php
@@ -1,0 +1,132 @@
+<?php
+
+namespace OpenDominion\Tests\Benchmark;
+
+/**
+ * Hard budgets for the tick, enforced by TickServiceBenchmarkTest.
+ *
+ * These are a RATCHET. Every value below was measured, not estimated. When an
+ * optimization lands, lower the relevant constant in the same commit - the
+ * lowered number is the evidence the fix worked, and it stops the gain being
+ * quietly given back later.
+ *
+ * Raising a constant is a deliberate act that needs justification in the commit
+ * message. It means the tick got more expensive on purpose.
+ *
+ * ---------------------------------------------------------------------------
+ * BASELINE: commit d287fd7a1, 2026-08-12
+ * Docker (php:8.5-apache, PHP 8.5.9, MariaDB 10.11), PHPUnit 12.5.24
+ * See phase0_headline.md for the full measurement.
+ * ---------------------------------------------------------------------------
+ *
+ * On tolerances. Query counts are near-deterministic but not perfectly so: over
+ * three baseline runs, N=40 returned 2358 every time while N=10 returned 611,
+ * 611 and 610. The fixture's row counts also drift slightly because
+ * createNonPlayer calls random_chance(), which is backed by random_int and
+ * cannot be seeded (see BenchmarkRoundSeeder::withDeterministicRandomness).
+ *
+ * So the tolerances below are sized against MEASURED noise, not guessed:
+ * observed noise is around 1 query in 2358 (0.04%), while any real regression -
+ * a relation no longer eager-loaded, a lookup pulled back into the loop - costs
+ * at least one query per dominion, i.e. 40 queries at N=40. The gap between
+ * those two magnitudes is three orders of magnitude, so a tolerance of a
+ * fraction of a query per dominion is both noise-proof and regression-tight.
+ */
+final class TickBenchmarkBudgets
+{
+    /**
+     * Dominion counts the scaling assertions run at. Small enough that the suite
+     * stays usable, far enough apart that the slope means something.
+     */
+    public const SMALL_N = 10;
+
+    public const LARGE_N = 40;
+
+    /**
+     * TickService::precalculateTick() for a single dominion.
+     *
+     * Measured: 19. Finding 2.1 of firstroundfindings.txt predicted "~19-20"
+     * from static analysis; this is that prediction confirmed exactly.
+     *
+     * Single dominion, single code path, no variance observed across runs, so
+     * this one is held at the measured value with no tolerance.
+     */
+    public const PRECALCULATE_MAX_QUERIES = 19;
+
+    /**
+     * TickService::performTick($round, $dominion) - the single-dominion branch
+     * used by the manual advance-tick path (MiscController.php:404) and by NPD
+     * generation.
+     *
+     * Measured: 91, stable across runs.
+     *
+     * This is HIGHER than the 77 recorded in phase0_headline.md, and the
+     * difference is real rather than noise. The single-dominion branch skips the
+     * eager-load at TickService.php:395-409 and does `collect([$dominion])`, so
+     * it inherits whatever relation state the CALLER's model happens to carry.
+     * precalculateTick then calls loadMissing() for race, race.perks, race.units
+     * and race.units.perks - free if the caller already hydrated them, 14 extra
+     * queries if not.
+     *
+     * The phase 0 report measured 77 because it profiled precalculateTick on the
+     * same model instance immediately beforehand, which left those relations
+     * warm. This budget deliberately holds the COLD number: it is the worst
+     * case, it is what a caller coming from a fresh fetch pays, and it is the
+     * shape that stays stable under test reordering.
+     */
+    public const SINGLE_DOMINION_TICK_MAX_QUERIES = 91;
+
+    /**
+     * Queries per dominion for a whole-round performTick() at LARGE_N.
+     *
+     * Measured: 58.95 (2358 queries / 40 dominions).
+     *
+     * Note this is THREE TIMES the precalculateTick figure above. Both findings
+     * reports anchored on precalculateTick and neither costed the rest of phase
+     * B; the loop's real per-dominion price is this number.
+     *
+     * Tolerance: 0.55 queries/dominion (22 queries at N=40). Twenty times the
+     * observed noise, and still fails on a regression of one query per dominion.
+     */
+    public const PER_DOMINION_MAX_QUERIES = 59.5;
+
+    /**
+     * Marginal queries per additional dominion, from the SMALL_N -> LARGE_N
+     * slope. This is what catches accidental superlinearity: it is a ratio of
+     * two measurements, so it carries more noise than either alone.
+     *
+     * Measured: 58.23 and 58.27 across runs. Budget is measured x 1.15.
+     */
+    public const MAX_MARGINAL_QUERIES = 67.0;
+
+    /**
+     * Phase A - the bulk join-updates against dominions, dominion_spells and
+     * dominion_queue at TickService.php:284-380.
+     *
+     * This is the part of the tick that is already right: three statements for
+     * the entire round, regardless of N. The budget exists to keep it that way,
+     * not because it is currently a problem.
+     */
+    public const PHASE_A_STATEMENTS = 3;
+
+    /**
+     * How many times any single statement may execute, per dominion.
+     *
+     * Measured: 6 - the spell_perk_types pivot select, which is both the most
+     * repeated statement and the slowest by total time (85 ms of 240 executions
+     * at N=40). That is the unmemoized perk rebuild of finding 2.3 surfacing as
+     * real queries, because $spell->perks is lazily loaded.
+     *
+     * Lower this to 3 when finding 2.2 (the lazy ->spell in cleanupActiveSpells)
+     * is fixed, and toward 1 when perk memoization lands.
+     */
+    public const MAX_REPEATS_PER_DOMINION = 6;
+
+    /**
+     * Matches only phase A's three join-updates. Laravel's MySQL grammar emits
+     * the join immediately after the table name on UPDATE, which distinguishes
+     * these from the per-dominion `update dominion_tick set ...` issued by
+     * $tick->save().
+     */
+    public const PHASE_A_PATTERN = '/^update\s+`(?:dominions|dominion_spells|dominion_queue)`\s+inner\s+join/i';
+}

--- a/tests/Benchmark/TickBenchmarkBudgets.php
+++ b/tests/Benchmark/TickBenchmarkBudgets.php
@@ -14,8 +14,21 @@ namespace OpenDominion\Tests\Benchmark;
  * message. It means the tick got more expensive on purpose.
  *
  * ---------------------------------------------------------------------------
- * BASELINE: 2026-08-12, after the phase 2 fixture correction
+ * CURRENT: after stage 0 of the optimization work
  * Docker (php:8.5-apache, PHP 8.5.9, MariaDB 10.11), PHPUnit 12.5.24
+ *
+ * Stage 0 moved the numbers as follows, all reproduced exactly across runs:
+ *
+ *     precalculateTick, one dominion      19    -> 16
+ *     performTick, single dominion (cold) 61    -> 49
+ *     queries per dominion                31.57 -> 22.20
+ *     marginal queries per dominion       30.90 -> 21.50
+ *     most-repeated statement per dominion 6.10 -> 1.20
+ *     wall time at N=40                   3974ms -> 1434ms
+ *
+ * The bulk of it came from one line: TickService.php:402 now eager-loads
+ * spells.perks alongside spells. Without it the first perk lookup of the tick
+ * lazily loaded perks once per active spell per dominion.
  * ---------------------------------------------------------------------------
  *
  * These numbers REPLACE the ones recorded in phase0_headline.md, which were
@@ -51,24 +64,25 @@ final class TickBenchmarkBudgets
     /**
      * TickService::precalculateTick() for a single dominion.
      *
-     * Measured: 19. Finding 2.1 of firstroundfindings.txt predicted "~19-20"
-     * from static analysis; this is that prediction confirmed exactly.
+     * Measured: 16, down from 19 after stage 0 removed the discarded
+     * getActiveSpells() call at TickService.php:1040 (a no-op since 2021).
+     * Finding 2.1 predicted "~19-20" from static analysis and was exactly right
+     * about the original.
      *
      * Single dominion, single code path, no variance across runs, so held at the
      * measured value with no tolerance.
      */
-    public const PRECALCULATE_MAX_QUERIES = 19;
+    public const PRECALCULATE_MAX_QUERIES = 16;
 
     /**
      * TickService::performTick($round, $dominion) - the single-dominion branch
      * used by the manual advance-tick path (MiscController.php:404) and by NPD
      * generation.
      *
-     * Measured: 60-61 across runs. Budget is one above the highest observed,
-     * because this is the only measurement that still drifts by a query - the
-     * whole-round numbers are exact. A regression that adds a single query to
-     * just this path is far less significant than one that adds a query per
-     * dominion, which PER_DOMINION_MAX_QUERIES catches tightly.
+     * Measured: 49, down from 60-61. It also stopped drifting: the ±1 variance
+     * this path used to show came from the lazy perk loads, whose count varied
+     * with how many spells happened to be active. Budget keeps one query of
+     * headroom anyway, since the drift may return.
      *
      * This branch skips the eager-load at TickService.php:395-409 and does
      * `collect([$dominion])`, so it inherits whatever relation state the CALLER's
@@ -82,30 +96,30 @@ final class TickBenchmarkBudgets
      * relations warm. That is also a real production shape - NPD generation does
      * exactly that at TickService.php:241-242.
      */
-    public const SINGLE_DOMINION_TICK_MAX_QUERIES = 62;
+    public const SINGLE_DOMINION_TICK_MAX_QUERIES = 50;
 
     /**
      * Queries per dominion for a whole-round performTick() at LARGE_N.
      *
-     * Measured: 31.57 (1263 queries / 40 dominions).
+     * Measured: 22.20 (888 queries / 40 dominions), down from 31.57.
      *
-     * Still well above the 19 that precalculateTick alone costs. Both findings
+     * Still above the 16 that precalculateTick alone costs. Both findings
      * reports anchored on precalculateTick and neither costed the rest of phase
      * B; the loop's real per-dominion price is this number.
      *
      * Tolerance: ~0.5 queries/dominion (about 20 queries at N=40), which fails on
      * a regression of one query per dominion.
      */
-    public const PER_DOMINION_MAX_QUERIES = 32.1;
+    public const PER_DOMINION_MAX_QUERIES = 22.7;
 
     /**
      * Marginal queries per additional dominion, from the SMALL_N -> LARGE_N
      * slope. This is what catches accidental superlinearity: it is a ratio of two
      * measurements, so it carries more noise than either alone.
      *
-     * Measured: 30.90. Budget is measured x 1.15.
+     * Measured: 21.50, down from 30.90. Budget is measured x 1.15.
      */
-    public const MAX_MARGINAL_QUERIES = 35.5;
+    public const MAX_MARGINAL_QUERIES = 24.7;
 
     /**
      * Phase A - the bulk join-updates against dominions, dominion_spells and
@@ -120,19 +134,21 @@ final class TickBenchmarkBudgets
     /**
      * How many times any single statement may execute, per dominion.
      *
-     * Measured: 6.10 (244 executions at N=40) - the spell_perk_types pivot
-     * select, which is both the most repeated statement and the slowest by total
-     * time. That is finding 2.3's unmemoized perk rebuilds surfacing as real
-     * queries, because $spell->perks is lazily loaded.
+     * Measured: 1.20, down from 6.10.
      *
-     * The .10 above a flat 6 is the three per-dominion N+1s inside
-     * performSpellEffects (finding 3.5), paid only by the SPECIAL_SPELL_RATIO of
-     * dominions carrying those spells.
+     * The old figure was the spell_perk_types pivot select, lazily loaded once
+     * per active spell per dominion because the tick's eager load omitted
+     * spells.perks. Adding it (TickService.php:402) collapsed six executions per
+     * dominion into one batched load per round.
      *
-     * Lower toward 3 when finding 2.2 (the lazy ->spell in cleanupActiveSpells)
-     * is fixed, and toward 1 when perk memoization lands.
+     * What remains at 1.20 is the lazy ->spell in cleanupActiveSpells
+     * (TickService.php:906, finding 2.2) - one select per expiring spell. Lower
+     * this toward 1 when that is batched against a Spell::all()->keyBy('id').
+     *
+     * Note this budget is now dominated by an N+1 over ROWS, not dominions, so
+     * it moves with the fixture's expiring-spell count as well as with the code.
      */
-    public const MAX_REPEATS_PER_DOMINION = 6.25;
+    public const MAX_REPEATS_PER_DOMINION = 1.5;
 
     /**
      * Matches only phase A's three join-updates. Laravel's MySQL grammar emits

--- a/tests/Benchmark/TickBenchmarkBudgets.php
+++ b/tests/Benchmark/TickBenchmarkBudgets.php
@@ -14,23 +14,29 @@ namespace OpenDominion\Tests\Benchmark;
  * message. It means the tick got more expensive on purpose.
  *
  * ---------------------------------------------------------------------------
- * BASELINE: commit d287fd7a1, 2026-08-12
+ * BASELINE: 2026-08-12, after the phase 2 fixture correction
  * Docker (php:8.5-apache, PHP 8.5.9, MariaDB 10.11), PHPUnit 12.5.24
- * See phase0_headline.md for the full measurement.
  * ---------------------------------------------------------------------------
  *
- * On tolerances. Query counts are near-deterministic but not perfectly so: over
- * three baseline runs, N=40 returned 2358 every time while N=10 returned 611,
- * 611 and 610. The fixture's row counts also drift slightly because
- * createNonPlayer calls random_chance(), which is backed by random_int and
- * cannot be seeded (see BenchmarkRoundSeeder::withDeterministicRandomness).
+ * These numbers REPLACE the ones recorded in phase0_headline.md, which were
+ * measured against a skewed fixture. BenchmarkRoundSeeder picked the spells
+ * carrying the most perks, and death_and_decay - which holds
+ * convert_peasants_to_self_military_unit1 - is among them. That put a
+ * performSpellEffects special case on every single dominion, so every dominion
+ * took a Dominion::update(), fired DominionSaved, and paid for a SECOND
+ * precalculateTick. Per-dominion cost read 58.95 where the common case is 31.57.
  *
- * So the tolerances below are sized against MEASURED noise, not guessed:
- * observed noise is around 1 query in 2358 (0.04%), while any real regression -
- * a relation no longer eager-loaded, a lookup pulled back into the loop - costs
- * at least one query per dominion, i.e. 40 queries at N=40. The gap between
- * those two magnitudes is three orders of magnitude, so a tolerance of a
- * fraction of a query per dominion is both noise-proof and regression-tight.
+ * The fixture now applies those spells to SPECIAL_SPELL_RATIO of dominions
+ * instead. Finding 3.4 of firstroundfindings.txt was right as written - the
+ * double precalculation is confined to affected dominions - and the corrected
+ * measurement puts a number on it: roughly 27 extra queries each.
+ *
+ * On tolerances. With the fixture corrected the counts are fully stable: 19, 61,
+ * 336 (N=10) and 1263 (N=40) reproduced exactly across runs, where the previous
+ * fixture drifted by a query at N=10. Tolerances are still sized against the
+ * gap between noise and a real regression: any regression worth catching costs
+ * at least one query per dominion, i.e. 40 queries at N=40, so a fraction of a
+ * query per dominion is both noise-proof and regression-tight.
  */
 final class TickBenchmarkBudgets
 {
@@ -48,8 +54,8 @@ final class TickBenchmarkBudgets
      * Measured: 19. Finding 2.1 of firstroundfindings.txt predicted "~19-20"
      * from static analysis; this is that prediction confirmed exactly.
      *
-     * Single dominion, single code path, no variance observed across runs, so
-     * this one is held at the measured value with no tolerance.
+     * Single dominion, single code path, no variance across runs, so held at the
+     * measured value with no tolerance.
      */
     public const PRECALCULATE_MAX_QUERIES = 19;
 
@@ -58,46 +64,48 @@ final class TickBenchmarkBudgets
      * used by the manual advance-tick path (MiscController.php:404) and by NPD
      * generation.
      *
-     * Measured: 91, stable across runs.
+     * Measured: 60-61 across runs. Budget is one above the highest observed,
+     * because this is the only measurement that still drifts by a query - the
+     * whole-round numbers are exact. A regression that adds a single query to
+     * just this path is far less significant than one that adds a query per
+     * dominion, which PER_DOMINION_MAX_QUERIES catches tightly.
      *
-     * This is HIGHER than the 77 recorded in phase0_headline.md, and the
-     * difference is real rather than noise. The single-dominion branch skips the
-     * eager-load at TickService.php:395-409 and does `collect([$dominion])`, so
-     * it inherits whatever relation state the CALLER's model happens to carry.
-     * precalculateTick then calls loadMissing() for race, race.perks, race.units
-     * and race.units.perks - free if the caller already hydrated them, 14 extra
-     * queries if not.
+     * This branch skips the eager-load at TickService.php:395-409 and does
+     * `collect([$dominion])`, so it inherits whatever relation state the CALLER's
+     * model carries. precalculateTick then calls loadMissing() for race,
+     * race.perks, race.units and race.units.perks - free if the caller already
+     * hydrated them, ~15 extra queries if not. This budget holds the COLD
+     * number: it is the worst case, and it is stable under test reordering.
      *
-     * The phase 0 report measured 77 because it profiled precalculateTick on the
-     * same model instance immediately beforehand, which left those relations
-     * warm. This budget deliberately holds the COLD number: it is the worst
-     * case, it is what a caller coming from a fresh fetch pays, and it is the
-     * shape that stays stable under test reordering.
+     * TickBaselineReportTest reports a lower figure for the same call because it
+     * profiles precalculateTick on the same instance first, leaving the
+     * relations warm. That is also a real production shape - NPD generation does
+     * exactly that at TickService.php:241-242.
      */
-    public const SINGLE_DOMINION_TICK_MAX_QUERIES = 91;
+    public const SINGLE_DOMINION_TICK_MAX_QUERIES = 62;
 
     /**
      * Queries per dominion for a whole-round performTick() at LARGE_N.
      *
-     * Measured: 58.95 (2358 queries / 40 dominions).
+     * Measured: 31.57 (1263 queries / 40 dominions).
      *
-     * Note this is THREE TIMES the precalculateTick figure above. Both findings
+     * Still well above the 19 that precalculateTick alone costs. Both findings
      * reports anchored on precalculateTick and neither costed the rest of phase
      * B; the loop's real per-dominion price is this number.
      *
-     * Tolerance: 0.55 queries/dominion (22 queries at N=40). Twenty times the
-     * observed noise, and still fails on a regression of one query per dominion.
+     * Tolerance: ~0.5 queries/dominion (about 20 queries at N=40), which fails on
+     * a regression of one query per dominion.
      */
-    public const PER_DOMINION_MAX_QUERIES = 59.5;
+    public const PER_DOMINION_MAX_QUERIES = 32.1;
 
     /**
      * Marginal queries per additional dominion, from the SMALL_N -> LARGE_N
-     * slope. This is what catches accidental superlinearity: it is a ratio of
-     * two measurements, so it carries more noise than either alone.
+     * slope. This is what catches accidental superlinearity: it is a ratio of two
+     * measurements, so it carries more noise than either alone.
      *
-     * Measured: 58.23 and 58.27 across runs. Budget is measured x 1.15.
+     * Measured: 30.90. Budget is measured x 1.15.
      */
-    public const MAX_MARGINAL_QUERIES = 67.0;
+    public const MAX_MARGINAL_QUERIES = 35.5;
 
     /**
      * Phase A - the bulk join-updates against dominions, dominion_spells and
@@ -112,15 +120,19 @@ final class TickBenchmarkBudgets
     /**
      * How many times any single statement may execute, per dominion.
      *
-     * Measured: 6 - the spell_perk_types pivot select, which is both the most
-     * repeated statement and the slowest by total time (85 ms of 240 executions
-     * at N=40). That is the unmemoized perk rebuild of finding 2.3 surfacing as
-     * real queries, because $spell->perks is lazily loaded.
+     * Measured: 6.10 (244 executions at N=40) - the spell_perk_types pivot
+     * select, which is both the most repeated statement and the slowest by total
+     * time. That is finding 2.3's unmemoized perk rebuilds surfacing as real
+     * queries, because $spell->perks is lazily loaded.
      *
-     * Lower this to 3 when finding 2.2 (the lazy ->spell in cleanupActiveSpells)
+     * The .10 above a flat 6 is the three per-dominion N+1s inside
+     * performSpellEffects (finding 3.5), paid only by the SPECIAL_SPELL_RATIO of
+     * dominions carrying those spells.
+     *
+     * Lower toward 3 when finding 2.2 (the lazy ->spell in cleanupActiveSpells)
      * is fixed, and toward 1 when perk memoization lands.
      */
-    public const MAX_REPEATS_PER_DOMINION = 6;
+    public const MAX_REPEATS_PER_DOMINION = 6.25;
 
     /**
      * Matches only phase A's three join-updates. Laravel's MySQL grammar emits
@@ -129,4 +141,11 @@ final class TickBenchmarkBudgets
      * $tick->save().
      */
     public const PHASE_A_PATTERN = '/^update\s+`(?:dominions|dominion_spells|dominion_queue)`\s+inner\s+join/i';
+
+    /**
+     * Matches the Tick::firstOrCreate lookup at the top of precalculateTick, and
+     * nothing else - the eager load of the tick relation uses `IN (...)`, and
+     * $tick->save() is an UPDATE. Counting these counts precalculateTick calls.
+     */
+    public const PRECALCULATE_INVOCATION_PATTERN = '/^select \* from `dominion_tick` where \(`dominion_id` = \?\)/i';
 }

--- a/tests/Benchmark/TickBenchmarkBudgets.php
+++ b/tests/Benchmark/TickBenchmarkBudgets.php
@@ -101,7 +101,8 @@ final class TickBenchmarkBudgets
     /**
      * Queries per dominion for a whole-round performTick() at LARGE_N.
      *
-     * Measured: 22.20 (888 queries / 40 dominions), down from 31.57.
+     * Measured: 21.23, down from 22.20 after skipping the cleanup deletes that
+     * matched no rows and removing the expiring-spell N+1.
      *
      * Still above the 16 that precalculateTick alone costs. Both findings
      * reports anchored on precalculateTick and neither costed the rest of phase
@@ -110,16 +111,16 @@ final class TickBenchmarkBudgets
      * Tolerance: ~0.5 queries/dominion (about 20 queries at N=40), which fails on
      * a regression of one query per dominion.
      */
-    public const PER_DOMINION_MAX_QUERIES = 22.7;
+    public const PER_DOMINION_MAX_QUERIES = 21.8;
 
     /**
      * Marginal queries per additional dominion, from the SMALL_N -> LARGE_N
      * slope. This is what catches accidental superlinearity: it is a ratio of two
      * measurements, so it carries more noise than either alone.
      *
-     * Measured: 21.50, down from 30.90. Budget is measured x 1.15.
+     * Measured: 20.47, down from 21.50. Budget is measured x 1.15.
      */
-    public const MAX_MARGINAL_QUERIES = 24.7;
+    public const MAX_MARGINAL_QUERIES = 23.5;
 
     /**
      * Phase A - the bulk join-updates against dominions, dominion_spells and
@@ -141,12 +142,12 @@ final class TickBenchmarkBudgets
      * spells.perks. Adding it (TickService.php:402) collapsed six executions per
      * dominion into one batched load per round.
      *
-     * What remains at 1.20 is the lazy ->spell in cleanupActiveSpells
-     * (TickService.php:906, finding 2.2) - one select per expiring spell. Lower
-     * this toward 1 when that is batched against a Spell::all()->keyBy('id').
-     *
-     * Note this budget is now dominated by an N+1 over ROWS, not dominions, so
-     * it moves with the fixture's expiring-spell count as well as with the code.
+     * The expiring-spell N+1 that used to sit here is gone - cleanupActiveSpells
+     * now resolves against a Spell collection keyed once per tick. The statement
+     * at 1.20 today is a different one: `select * from dominions where id = ?`,
+     * which is precalculateTick's fresh-row refetch plus the lazy
+     * $dominionSpell->dominion in performSpellEffects. Same rate, different
+     * cause - do not read a flat budget here as "nothing changed".
      */
     public const MAX_REPEATS_PER_DOMINION = 1.5;
 

--- a/tests/Benchmark/TickFindingsBenchmarkTest.php
+++ b/tests/Benchmark/TickFindingsBenchmarkTest.php
@@ -153,21 +153,17 @@ class TickFindingsBenchmarkTest extends AbstractTickBenchmarkTestCase
     }
 
     /**
-     * CHARACTERIZATION - finding 3.7.
+     * REGRESSION GUARD - finding 3.7, fixed.
      *
-     * tickDaily() opens with Round::with('dominions')->active()->get()
-     * (TickService.php:726) and then never reads the loaded relation: the body
-     * uses $round->realms(), $round->dominions() (a fresh query builder, not the
-     * relation) and $round->daysInRound(). The eager load hydrates a full model
-     * per dominion in the round for nothing.
+     * tickDaily() used to open with Round::with('dominions')->active()->get(),
+     * hydrating a full model for every dominion in the round and reading none of
+     * them: the body uses $round->realms(), $round->dominions() (a fresh query
+     * builder, not the relation) and $round->daysInRound().
      *
-     * Query COUNT does not reveal this - it is one statement regardless of N -
-     * so this asserts the statement is issued at all.
-     *
-     * WHEN 3.7 IS FIXED: drop the with('dominions'), this assertion fails, and it
-     * should be inverted to assertSame(0, ...).
+     * Query COUNT alone would not catch a reintroduction - it is one statement
+     * regardless of N - so this asserts the statement is absent entirely.
      */
-    public function testTickDailyEagerLoadsDominionsItNeverReads(): void
+    public function testTickDailyDoesNotEagerLoadDominions(): void
     {
         $fixture = $this->seeder->seed(TickBenchmarkBudgets::SMALL_N);
         $tickService = $this->tickService();
@@ -185,18 +181,18 @@ class TickFindingsBenchmarkTest extends AbstractTickBenchmarkTestCase
         $deadLoads = $profile->countMatchingPattern('/^select `dominions`\.\*.*from `dominions`.*`realms`/is');
 
         $this->write(sprintf(
-            "  tickDaily(): %d queries total, %d of them the dead dominions eager-load%s",
+            "  tickDaily(): %d queries total, %d of them a dominions eager-load%s",
             $profile->queryCount(),
             $deadLoads,
             PHP_EOL
         ));
 
-        $this->assertGreaterThan(
+        $this->assertSame(
             0,
             $deadLoads,
-            "Expected tickDaily() to still perform the dead with('dominions') eager load described by finding 3.7.\n"
-            . "Seeing zero means it has been removed - invert this assertion to assertSame(0, \$deadLoads) and "
-            . "record the win.\n\n"
+            "tickDaily() is eager-loading dominions again (finding 3.7). The body reads none of them - "
+            . "it uses \$round->realms() and \$round->dominions(), both fresh query builders - so this "
+            . "hydrates a model per dominion in the round for nothing.\n\n"
             . $profile->render()
         );
     }

--- a/tests/Benchmark/TickFindingsBenchmarkTest.php
+++ b/tests/Benchmark/TickFindingsBenchmarkTest.php
@@ -1,0 +1,292 @@
+<?php
+
+namespace OpenDominion\Tests\Benchmark;
+
+use DB;
+use OpenDominion\Services\Dominion\TickService;
+use PHPUnit\Framework\Attributes\Group;
+
+/**
+ * Phase 2: tests pinned to individual findings from firstroundfindings.txt and
+ * secondroundfindings.txt, rather than to aggregate budgets.
+ *
+ * Two kinds of test live here:
+ *
+ *  - BUDGETS, which assert a cost stays within bounds. These behave like phase
+ *    1: lower the bound when the finding is fixed.
+ *
+ *  - CHARACTERIZATIONS, which assert that an unfixed finding still behaves the
+ *    way it currently does. These exist so the finding is measured rather than
+ *    merely described, and so that fixing it produces a loud, specific failure
+ *    that points at the test to invert. They are labelled CHARACTERIZATION and
+ *    each says what to change when it breaks.
+ */
+#[Group('benchmark')]
+class TickFindingsBenchmarkTest extends AbstractTickBenchmarkTestCase
+{
+    /**
+     * Finding 3.4 - DominionSaved fires inside the tick and duplicates the work.
+     *
+     * performSpellEffects calls $dominion->update() for the Cull the Weak,
+     * Death and Decay and Dark Elf special cases. Every update dispatches
+     * DominionSavedEvent, whose listener runs a full networth calculation AND a
+     * second precalculateTick - which the main loop then does again.
+     *
+     * This test pins the SCOPE of that duplication: exactly the dominions
+     * carrying one of those spells, and no others. It is the assertion that
+     * would have caught the skewed fixture that produced the phase 0 numbers.
+     */
+    public function testPrecalculateTickRunsOncePerDominionPlusOncePerSpecialSpell(): void
+    {
+        $fixture = $this->seeder->seed(TickBenchmarkBudgets::LARGE_N);
+        $tickService = $this->tickService();
+
+        $this->warmUp($fixture);
+
+        $profile = $this->profiler->profile(
+            'precalculateTick invocations',
+            static function () use ($tickService, $fixture): void {
+                $tickService->performTick($fixture->round);
+            },
+            TickBenchmarkBudgets::LARGE_N
+        );
+
+        $invocations = $profile->countMatchingPattern(
+            TickBenchmarkBudgets::PRECALCULATE_INVOCATION_PATTERN
+        );
+
+        $expected = $fixture->dominionCount() + $fixture->specialSpellCount;
+
+        $this->write(sprintf(
+            "  precalculateTick invocations: %d for %d dominions (%d carrying a special spell)%s",
+            $invocations,
+            $fixture->dominionCount(),
+            $fixture->specialSpellCount,
+            PHP_EOL
+        ));
+
+        $this->assertSame(
+            $expected,
+            $invocations,
+            sprintf(
+                "Expected %d precalculateTick calls (one per dominion, plus one more for each of the %d "
+                . "carrying a performSpellEffects special-case spell), saw %d.\n\n"
+                . "MORE than expected means DominionSaved is now firing for dominions it did not before - "
+                . "every extra call is roughly %d wasted queries.\n"
+                . "FEWER means finding 3.4 has been fixed; update this test to expect one call per dominion.",
+                $expected,
+                $fixture->specialSpellCount,
+                $invocations,
+                TickBenchmarkBudgets::PRECALCULATE_MAX_QUERIES
+            )
+        );
+    }
+
+    /**
+     * CHARACTERIZATION - finding M1 of secondroundfindings.txt.
+     *
+     * Phase A only touches dominions with protection_finished = true
+     * (TickService.php:275). Phase B iterates $round->activeDominions(), which is
+     * only filtered on locked_at (Round.php:80-83) - so every dominion still in
+     * protection pays the full per-dominion cost each hour despite phase A having
+     * changed nothing about it.
+     *
+     * In the opening days of a round those dominions are a large share of N, so
+     * this is at its worst exactly when the game is busiest.
+     *
+     * WHEN M1 IS FIXED: the cost of the half-in-protection round drops to roughly
+     * half, this assertion fails, and it should be inverted to assert that
+     * protection dominions are excluded.
+     */
+    public function testProtectionDominionsStillPayFullPhaseBCost(): void
+    {
+        $half = (int)(TickBenchmarkBudgets::LARGE_N / 2);
+
+        $allActive = $this->seeder->seed(TickBenchmarkBudgets::LARGE_N);
+        $halfProtected = $this->seeder->seed(TickBenchmarkBudgets::LARGE_N, $half);
+
+        $tickService = $this->tickService();
+
+        $this->warmUp($allActive, $halfProtected);
+
+        $activeProfile = $this->profiler->profile(
+            'all active',
+            static function () use ($tickService, $allActive): void {
+                $tickService->performTick($allActive->round);
+            },
+            TickBenchmarkBudgets::LARGE_N
+        );
+
+        $protectedProfile = $this->profiler->profile(
+            'half in protection',
+            static function () use ($tickService, $halfProtected): void {
+                $tickService->performTick($halfProtected->round);
+            },
+            TickBenchmarkBudgets::LARGE_N
+        );
+
+        $ratio = $protectedProfile->queryCount() / $activeProfile->queryCount();
+
+        $this->write(sprintf(
+            "  phase B with %d/%d in protection: %d queries vs %d all-active (%.0f%%)%s",
+            $half,
+            TickBenchmarkBudgets::LARGE_N,
+            $protectedProfile->queryCount(),
+            $activeProfile->queryCount(),
+            $ratio * 100,
+            PHP_EOL
+        ));
+
+        $this->assertGreaterThan(
+            0.9,
+            $ratio,
+            sprintf(
+                "A round with half its dominions in protection cost %.0f%% of a fully active one (%d vs %d queries).\n\n"
+                . "This test CHARACTERIZES finding M1: protection dominions are expected to cost the same as active "
+                . "ones today, because phase B does not filter on protection_finished.\n"
+                . 'A ratio near 0.5 means M1 has been fixed - invert this assertion to assert the saving.',
+                $ratio * 100,
+                $protectedProfile->queryCount(),
+                $activeProfile->queryCount()
+            )
+        );
+    }
+
+    /**
+     * CHARACTERIZATION - finding 3.7.
+     *
+     * tickDaily() opens with Round::with('dominions')->active()->get()
+     * (TickService.php:726) and then never reads the loaded relation: the body
+     * uses $round->realms(), $round->dominions() (a fresh query builder, not the
+     * relation) and $round->daysInRound(). The eager load hydrates a full model
+     * per dominion in the round for nothing.
+     *
+     * Query COUNT does not reveal this - it is one statement regardless of N -
+     * so this asserts the statement is issued at all.
+     *
+     * WHEN 3.7 IS FIXED: drop the with('dominions'), this assertion fails, and it
+     * should be inverted to assertSame(0, ...).
+     */
+    public function testTickDailyEagerLoadsDominionsItNeverReads(): void
+    {
+        $fixture = $this->seeder->seed(TickBenchmarkBudgets::SMALL_N);
+        $tickService = $this->tickService();
+
+        $this->warmUp($fixture);
+
+        $profile = $this->profiler->profile(
+            'tickDaily',
+            static function () use ($tickService): void {
+                $tickService->tickDaily();
+            },
+            TickBenchmarkBudgets::SMALL_N
+        );
+
+        $deadLoads = $profile->countMatchingPattern('/^select `dominions`\.\*.*from `dominions`.*`realms`/is');
+
+        $this->write(sprintf(
+            "  tickDaily(): %d queries total, %d of them the dead dominions eager-load%s",
+            $profile->queryCount(),
+            $deadLoads,
+            PHP_EOL
+        ));
+
+        $this->assertGreaterThan(
+            0,
+            $deadLoads,
+            "Expected tickDaily() to still perform the dead with('dominions') eager load described by finding 3.7.\n"
+            . "Seeing zero means it has been removed - invert this assertion to assertSame(0, \$deadLoads) and "
+            . "record the win.\n\n"
+            . $profile->render()
+        );
+    }
+
+    /**
+     * Finding 4.1 - the daily-rankings self-join is quadratic and unindexed.
+     *
+     * daily_rankings carries only unique(dominion_id, key); there is no index on
+     * (round_id, key, value), so the range self-join at TickService.php:1228 has
+     * nothing to seek on. With ~20 ranking keys and N dominions the table holds
+     * ~20N rows and the join compares on the order of 20 x N^2 row pairs.
+     *
+     * Reported, not asserted. The cost lives INSIDE one statement, so query
+     * counts cannot see it and only timing can - and timing is machine-dependent.
+     * A hard budget here would be a flaky test; the number is here to be read
+     * before and after the window-function rewrite.
+     */
+    public function testReportDailyRankingsScaling(): void
+    {
+        $tickService = $this->tickService();
+
+        // updateDailyRankings() takes no round argument - it loops every round
+        // matching Round::activeRankings(). The two measurements must therefore
+        // be isolated by taking the first round out of scope before seeding the
+        // second, or the large run would re-rank the small round as well and the
+        // comparison would measure nothing.
+        $small = $this->seeder->seed(TickBenchmarkBudgets::SMALL_N);
+        $this->warmUp($small);
+        $smallProfile = $this->profileRankings($tickService, 'rankings, small');
+
+        $this->expireRound($small->round->id);
+
+        $large = $this->seeder->seed(TickBenchmarkBudgets::LARGE_N);
+        $this->warmUp($large);
+        $largeProfile = $this->profileRankings($tickService, 'rankings, large');
+
+        $ratio = $smallProfile > 0 ? $largeProfile / $smallProfile : 0;
+        $dataRatio = TickBenchmarkBudgets::LARGE_N / TickBenchmarkBudgets::SMALL_N;
+
+        $this->write(sprintf(
+            "\n  daily rankings self-join\n"
+            . "    N = %-4d %8.1f ms\n"
+            . "    N = %-4d %8.1f ms\n"
+            . "    growth   %.2fx for %.2fx the dominions\n"
+            . "    (linear would be ~%.2fx; quadratic ~%.2fx)\n\n",
+            TickBenchmarkBudgets::SMALL_N,
+            $smallProfile,
+            TickBenchmarkBudgets::LARGE_N,
+            $largeProfile,
+            $ratio,
+            $dataRatio,
+            $dataRatio,
+            $dataRatio ** 2
+        ));
+
+        $this->assertGreaterThan(0.0, $largeProfile, 'Expected the ranking statements to take measurable time.');
+    }
+
+    /**
+     * Moves a round's end_date into the past so Round::activeRankings() stops
+     * matching it.
+     */
+    private function expireRound(int $roundId): void
+    {
+        DB::table('rounds')
+            ->where('id', $roundId)
+            ->update(['end_date' => now()->subDays(1)]);
+    }
+
+    /**
+     * Runs updateDailyRankings and returns the total time spent in
+     * daily_rankings statements, in milliseconds.
+     */
+    private function profileRankings(TickService $tickService, string $label): float
+    {
+        $profile = $this->profiler->profile(
+            $label,
+            static function () use ($tickService): void {
+                $tickService->updateDailyRankings();
+            }
+        );
+
+        $total = 0.0;
+
+        foreach ($profile->slowestGroups(50) as $sql => $stats) {
+            if (stripos($sql, 'daily_rankings') !== false) {
+                $total += $stats['totalMs'];
+            }
+        }
+
+        return $total;
+    }
+}

--- a/tests/Benchmark/TickFindingsBenchmarkTest.php
+++ b/tests/Benchmark/TickFindingsBenchmarkTest.php
@@ -58,7 +58,7 @@ class TickFindingsBenchmarkTest extends AbstractTickBenchmarkTestCase
         $expected = $fixture->dominionCount() + $fixture->specialSpellCount;
 
         $this->write(sprintf(
-            "  precalculateTick invocations: %d for %d dominions (%d carrying a special spell)%s",
+            '  precalculateTick invocations: %d for %d dominions (%d carrying a special spell)%s',
             $invocations,
             $fixture->dominionCount(),
             $fixture->specialSpellCount,
@@ -69,11 +69,11 @@ class TickFindingsBenchmarkTest extends AbstractTickBenchmarkTestCase
             $expected,
             $invocations,
             sprintf(
-                "Expected %d precalculateTick calls (one per dominion, plus one more for each of the %d "
+                'Expected %d precalculateTick calls (one per dominion, plus one more for each of the %d '
                 . "carrying a performSpellEffects special-case spell), saw %d.\n\n"
-                . "MORE than expected means DominionSaved is now firing for dominions it did not before - "
+                . 'MORE than expected means DominionSaved is now firing for dominions it did not before - '
                 . "every extra call is roughly %d wasted queries.\n"
-                . "FEWER means finding 3.4 has been fixed; update this test to expect one call per dominion.",
+                . 'FEWER means finding 3.4 has been fixed; update this test to expect one call per dominion.',
                 $expected,
                 $fixture->specialSpellCount,
                 $invocations,
@@ -128,7 +128,7 @@ class TickFindingsBenchmarkTest extends AbstractTickBenchmarkTestCase
         $ratio = $protectedProfile->queryCount() / $activeProfile->queryCount();
 
         $this->write(sprintf(
-            "  phase B with %d/%d in protection: %d queries vs %d all-active (%.0f%%)%s",
+            '  phase B with %d/%d in protection: %d queries vs %d all-active (%.0f%%)%s',
             $half,
             TickBenchmarkBudgets::LARGE_N,
             $protectedProfile->queryCount(),
@@ -142,7 +142,7 @@ class TickFindingsBenchmarkTest extends AbstractTickBenchmarkTestCase
             $ratio,
             sprintf(
                 "A round with half its dominions in protection cost %.0f%% of a fully active one (%d vs %d queries).\n\n"
-                . "This test CHARACTERIZES finding M1: protection dominions are expected to cost the same as active "
+                . 'This test CHARACTERIZES finding M1: protection dominions are expected to cost the same as active '
                 . "ones today, because phase B does not filter on protection_finished.\n"
                 . 'A ratio near 0.5 means M1 has been fixed - invert this assertion to assert the saving.',
                 $ratio * 100,
@@ -181,7 +181,7 @@ class TickFindingsBenchmarkTest extends AbstractTickBenchmarkTestCase
         $deadLoads = $profile->countMatchingPattern('/^select `dominions`\.\*.*from `dominions`.*`realms`/is');
 
         $this->write(sprintf(
-            "  tickDaily(): %d queries total, %d of them a dominions eager-load%s",
+            '  tickDaily(): %d queries total, %d of them a dominions eager-load%s',
             $profile->queryCount(),
             $deadLoads,
             PHP_EOL
@@ -190,8 +190,8 @@ class TickFindingsBenchmarkTest extends AbstractTickBenchmarkTestCase
         $this->assertSame(
             0,
             $deadLoads,
-            "tickDaily() is eager-loading dominions again (finding 3.7). The body reads none of them - "
-            . "it uses \$round->realms() and \$round->dominions(), both fresh query builders - so this "
+            'tickDaily() is eager-loading dominions again (finding 3.7). The body reads none of them - '
+            . 'it uses $round->realms() and $round->dominions(), both fresh query builders - so this '
             . "hydrates a model per dominion in the round for nothing.\n\n"
             . $profile->render()
         );

--- a/tests/Benchmark/TickServiceBenchmarkTest.php
+++ b/tests/Benchmark/TickServiceBenchmarkTest.php
@@ -42,6 +42,12 @@ class TickServiceBenchmarkTest extends AbstractTickBenchmarkTestCase
             1
         );
 
+        $this->reportBudget(
+            'precalculateTick(), one dominion',
+            $profile->queryCount(),
+            TickBenchmarkBudgets::PRECALCULATE_MAX_QUERIES
+        );
+
         $this->assertLessThanOrEqual(
             TickBenchmarkBudgets::PRECALCULATE_MAX_QUERIES,
             $profile->queryCount(),
@@ -76,6 +82,12 @@ class TickServiceBenchmarkTest extends AbstractTickBenchmarkTestCase
             1
         );
 
+        $this->reportBudget(
+            'performTick(), single dominion (cold relations)',
+            $profile->queryCount(),
+            TickBenchmarkBudgets::SINGLE_DOMINION_TICK_MAX_QUERIES
+        );
+
         $this->assertLessThanOrEqual(
             TickBenchmarkBudgets::SINGLE_DOMINION_TICK_MAX_QUERIES,
             $profile->queryCount(),
@@ -106,6 +118,12 @@ class TickServiceBenchmarkTest extends AbstractTickBenchmarkTestCase
                 $tickService->performTick($fixture->round);
             },
             TickBenchmarkBudgets::LARGE_N
+        );
+
+        $this->reportBudget(
+            'performTick(), queries per dominion',
+            $profile->queriesPerDominion(),
+            TickBenchmarkBudgets::PER_DOMINION_MAX_QUERIES
         );
 
         $this->assertLessThanOrEqual(
@@ -155,6 +173,12 @@ class TickServiceBenchmarkTest extends AbstractTickBenchmarkTestCase
 
         $marginal = ($largeProfile->queryCount() - $smallProfile->queryCount())
             / (TickBenchmarkBudgets::LARGE_N - TickBenchmarkBudgets::SMALL_N);
+
+        $this->reportBudget(
+            'marginal queries per additional dominion',
+            $marginal,
+            TickBenchmarkBudgets::MAX_MARGINAL_QUERIES
+        );
 
         $this->assertLessThanOrEqual(
             TickBenchmarkBudgets::MAX_MARGINAL_QUERIES,
@@ -207,6 +231,19 @@ class TickServiceBenchmarkTest extends AbstractTickBenchmarkTestCase
 
         $smallCount = $smallProfile->countMatchingPattern(TickBenchmarkBudgets::PHASE_A_PATTERN);
         $largeCount = $largeProfile->countMatchingPattern(TickBenchmarkBudgets::PHASE_A_PATTERN);
+
+        $this->reportBudget(
+            'phase A statements (N=' . TickBenchmarkBudgets::SMALL_N . ')',
+            $smallCount,
+            TickBenchmarkBudgets::PHASE_A_STATEMENTS,
+            'statements'
+        );
+        $this->reportBudget(
+            'phase A statements (N=' . TickBenchmarkBudgets::LARGE_N . ')',
+            $largeCount,
+            TickBenchmarkBudgets::PHASE_A_STATEMENTS,
+            'statements'
+        );
 
         $this->assertSame(
             TickBenchmarkBudgets::PHASE_A_STATEMENTS,
@@ -262,6 +299,13 @@ class TickServiceBenchmarkTest extends AbstractTickBenchmarkTestCase
         $this->assertNotNull($worst, 'Expected the tick to issue at least one repeated statement.');
 
         [$sql, $count] = $worst;
+
+        $this->reportBudget(
+            'most-repeated statement, per dominion',
+            $count / TickBenchmarkBudgets::LARGE_N,
+            TickBenchmarkBudgets::MAX_REPEATS_PER_DOMINION,
+            'executions'
+        );
 
         $this->assertLessThanOrEqual(
             $ceiling,

--- a/tests/Benchmark/TickServiceBenchmarkTest.php
+++ b/tests/Benchmark/TickServiceBenchmarkTest.php
@@ -1,0 +1,304 @@
+<?php
+
+namespace OpenDominion\Tests\Benchmark;
+
+use OpenDominion\Models\Dominion;
+use OpenDominion\Tests\Benchmark\Support\TickProfile;
+use PHPUnit\Framework\Attributes\Group;
+
+/**
+ * Phase 1: the budgets from phase 0, enforced.
+ *
+ * These tests FAIL when the tick gets more expensive. Every number they assert
+ * against lives in TickBenchmarkBudgets with the measurement that produced it.
+ *
+ * Run with:
+ *   php artisan test --group=benchmark
+ *
+ * Assertions are on query counts only. Wall time is reported by
+ * TickBaselineReportTest but never asserted - it is machine-dependent, and a
+ * benchmark that fails because CI was busy is a benchmark people learn to skip.
+ */
+#[Group('benchmark')]
+class TickServiceBenchmarkTest extends AbstractTickBenchmarkTestCase
+{
+    /**
+     * Finding 2.1: precalculateTick re-queries relations the tick already
+     * eager-loaded, at roughly 20 queries per dominion.
+     */
+    public function testPrecalculateTickStaysWithinQueryBudget(): void
+    {
+        $fixture = $this->seeder->seed(1);
+        $tickService = $this->tickService();
+        $dominion = Dominion::findOrFail($fixture->dominionIds[0]);
+
+        $this->warmUp($fixture);
+
+        $profile = $this->profiler->profile(
+            'precalculateTick budget',
+            static function () use ($tickService, $dominion): void {
+                $tickService->precalculateTick($dominion);
+            },
+            1
+        );
+
+        $this->assertLessThanOrEqual(
+            TickBenchmarkBudgets::PRECALCULATE_MAX_QUERIES,
+            $profile->queryCount(),
+            $this->explain(
+                $profile,
+                sprintf(
+                    'precalculateTick() issued %d queries, budget is %d.',
+                    $profile->queryCount(),
+                    TickBenchmarkBudgets::PRECALCULATE_MAX_QUERIES
+                )
+            )
+        );
+    }
+
+    /**
+     * The single-dominion branch, used by the manual advance-tick path
+     * (MiscController.php:404) and by NPD generation.
+     */
+    public function testSingleDominionTickStaysWithinQueryBudget(): void
+    {
+        $fixture = $this->seeder->seed(1);
+        $tickService = $this->tickService();
+        $dominion = Dominion::findOrFail($fixture->dominionIds[0]);
+
+        $this->warmUp($fixture);
+
+        $profile = $this->profiler->profile(
+            'single-dominion performTick budget',
+            static function () use ($tickService, $fixture, $dominion): void {
+                $tickService->performTick($fixture->round, $dominion);
+            },
+            1
+        );
+
+        $this->assertLessThanOrEqual(
+            TickBenchmarkBudgets::SINGLE_DOMINION_TICK_MAX_QUERIES,
+            $profile->queryCount(),
+            $this->explain(
+                $profile,
+                sprintf(
+                    'performTick($round, $dominion) issued %d queries, budget is %d.',
+                    $profile->queryCount(),
+                    TickBenchmarkBudgets::SINGLE_DOMINION_TICK_MAX_QUERIES
+                )
+            )
+        );
+    }
+
+    /**
+     * The headline budget: what one more dominion in a round costs.
+     */
+    public function testPerDominionQueryCountStaysWithinBudget(): void
+    {
+        $fixture = $this->seeder->seed(TickBenchmarkBudgets::LARGE_N);
+        $tickService = $this->tickService();
+
+        $this->warmUp($fixture);
+
+        $profile = $this->profiler->profile(
+            'per-dominion budget',
+            static function () use ($tickService, $fixture): void {
+                $tickService->performTick($fixture->round);
+            },
+            TickBenchmarkBudgets::LARGE_N
+        );
+
+        $this->assertLessThanOrEqual(
+            TickBenchmarkBudgets::PER_DOMINION_MAX_QUERIES,
+            $profile->queriesPerDominion(),
+            $this->explain(
+                $profile,
+                sprintf(
+                    'performTick() cost %.2f queries per dominion (%d total for %d dominions), budget is %.2f.',
+                    $profile->queriesPerDominion(),
+                    $profile->queryCount(),
+                    TickBenchmarkBudgets::LARGE_N,
+                    TickBenchmarkBudgets::PER_DOMINION_MAX_QUERIES
+                )
+            )
+        );
+    }
+
+    /**
+     * Guards against superlinearity. A per-dominion budget alone would not catch
+     * a cost that only appears at scale - this compares the marginal cost
+     * between two round sizes.
+     */
+    public function testPerformTickScalesLinearlyWithDominionCount(): void
+    {
+        $small = $this->seeder->seed(TickBenchmarkBudgets::SMALL_N);
+        $large = $this->seeder->seed(TickBenchmarkBudgets::LARGE_N);
+        $tickService = $this->tickService();
+
+        $this->warmUp($small, $large);
+
+        $smallProfile = $this->profiler->profile(
+            'scaling, small',
+            static function () use ($tickService, $small): void {
+                $tickService->performTick($small->round);
+            },
+            TickBenchmarkBudgets::SMALL_N
+        );
+
+        $largeProfile = $this->profiler->profile(
+            'scaling, large',
+            static function () use ($tickService, $large): void {
+                $tickService->performTick($large->round);
+            },
+            TickBenchmarkBudgets::LARGE_N
+        );
+
+        $marginal = ($largeProfile->queryCount() - $smallProfile->queryCount())
+            / (TickBenchmarkBudgets::LARGE_N - TickBenchmarkBudgets::SMALL_N);
+
+        $this->assertLessThanOrEqual(
+            TickBenchmarkBudgets::MAX_MARGINAL_QUERIES,
+            $marginal,
+            $this->explain(
+                $largeProfile,
+                sprintf(
+                    "Each additional dominion cost %.2f queries, budget is %.2f.\n"
+                    . "N=%d: %d queries. N=%d: %d queries.\n"
+                    . 'A marginal cost above the per-dominion average means something is superlinear.',
+                    $marginal,
+                    TickBenchmarkBudgets::MAX_MARGINAL_QUERIES,
+                    TickBenchmarkBudgets::SMALL_N,
+                    $smallProfile->queryCount(),
+                    TickBenchmarkBudgets::LARGE_N,
+                    $largeProfile->queryCount()
+                )
+            )
+        );
+    }
+
+    /**
+     * Protects the part of the tick that is already well built: phase A applies
+     * every precomputed delta for the whole round in three statements, and must
+     * stay at three no matter how many dominions there are.
+     */
+    public function testPhaseAIsConstantRegardlessOfDominionCount(): void
+    {
+        $small = $this->seeder->seed(TickBenchmarkBudgets::SMALL_N);
+        $large = $this->seeder->seed(TickBenchmarkBudgets::LARGE_N);
+        $tickService = $this->tickService();
+
+        $this->warmUp($small, $large);
+
+        $smallProfile = $this->profiler->profile(
+            'phase A, small',
+            static function () use ($tickService, $small): void {
+                $tickService->performTick($small->round);
+            },
+            TickBenchmarkBudgets::SMALL_N
+        );
+
+        $largeProfile = $this->profiler->profile(
+            'phase A, large',
+            static function () use ($tickService, $large): void {
+                $tickService->performTick($large->round);
+            },
+            TickBenchmarkBudgets::LARGE_N
+        );
+
+        $smallCount = $smallProfile->countMatchingPattern(TickBenchmarkBudgets::PHASE_A_PATTERN);
+        $largeCount = $largeProfile->countMatchingPattern(TickBenchmarkBudgets::PHASE_A_PATTERN);
+
+        $this->assertSame(
+            TickBenchmarkBudgets::PHASE_A_STATEMENTS,
+            $smallCount,
+            sprintf(
+                "Phase A issued %d bulk statements at N=%d, expected %d. Saw:\n%s",
+                $smallCount,
+                TickBenchmarkBudgets::SMALL_N,
+                TickBenchmarkBudgets::PHASE_A_STATEMENTS,
+                $this->formatStatements($smallProfile->statementsMatching(TickBenchmarkBudgets::PHASE_A_PATTERN))
+            )
+        );
+
+        $this->assertSame(
+            $smallCount,
+            $largeCount,
+            sprintf(
+                'Phase A issued %d bulk statements at N=%d but %d at N=%d - it is no longer constant in the number of dominions.',
+                $smallCount,
+                TickBenchmarkBudgets::SMALL_N,
+                $largeCount,
+                TickBenchmarkBudgets::LARGE_N
+            )
+        );
+    }
+
+    /**
+     * The N+1 detector. Any statement executed once per dominion (or worse, once
+     * per row) rises to the top of duplicateGroups().
+     *
+     * Currently the ceiling is set by the spell_perk_types pivot select at 6 per
+     * dominion - finding 2.3's unmemoized perk rebuilds. Lower the budget as
+     * those are fixed.
+     */
+    public function testNoStatementRepeatsMoreThanBudgetPerDominion(): void
+    {
+        $fixture = $this->seeder->seed(TickBenchmarkBudgets::LARGE_N);
+        $tickService = $this->tickService();
+
+        $this->warmUp($fixture);
+
+        $profile = $this->profiler->profile(
+            'repeat budget',
+            static function () use ($tickService, $fixture): void {
+                $tickService->performTick($fixture->round);
+            },
+            TickBenchmarkBudgets::LARGE_N
+        );
+
+        $ceiling = TickBenchmarkBudgets::MAX_REPEATS_PER_DOMINION * TickBenchmarkBudgets::LARGE_N;
+        $worst = $profile->mostRepeatedStatement();
+
+        $this->assertNotNull($worst, 'Expected the tick to issue at least one repeated statement.');
+
+        [$sql, $count] = $worst;
+
+        $this->assertLessThanOrEqual(
+            $ceiling,
+            $count,
+            sprintf(
+                "A single statement ran %d times for %d dominions (%.2f per dominion), budget is %d per dominion.\n"
+                . "Statement:\n  %s\n\nTop repeats:\n%s",
+                $count,
+                TickBenchmarkBudgets::LARGE_N,
+                $count / TickBenchmarkBudgets::LARGE_N,
+                TickBenchmarkBudgets::MAX_REPEATS_PER_DOMINION,
+                $sql,
+                $this->formatStatements($profile->duplicateGroups(), 10)
+            )
+        );
+    }
+
+    /**
+     * Appends the full profile to a failure message. A budget failure should say
+     * what broke it, not just that something did.
+     */
+    private function explain(TickProfile $profile, string $message): string
+    {
+        return $message . PHP_EOL . PHP_EOL . $profile->render();
+    }
+
+    /**
+     * @param array<string, int> $statements
+     */
+    private function formatStatements(array $statements, int $limit = 5): string
+    {
+        $lines = [];
+
+        foreach (array_slice($statements, 0, $limit, true) as $sql => $count) {
+            $lines[] = sprintf('  %6dx  %s', $count, $sql);
+        }
+
+        return $lines === [] ? '  (none)' : implode(PHP_EOL, $lines);
+    }
+}

--- a/tests/Unit/Calculators/ValorCalculatorTest.php
+++ b/tests/Unit/Calculators/ValorCalculatorTest.php
@@ -1,0 +1,348 @@
+<?php
+
+namespace OpenDominion\Tests\Unit\Calculators;
+
+use Illuminate\Database\Eloquent\Collection as EloquentCollection;
+use OpenDominion\Calculators\Dominion\LandCalculator;
+use OpenDominion\Calculators\ValorCalculator;
+use OpenDominion\Models\DailyRanking;
+use OpenDominion\Models\Dominion;
+use OpenDominion\Models\Round;
+use OpenDominion\Models\Valor;
+use OpenDominion\Services\QueryProfilerService;
+use OpenDominion\Tests\AbstractTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+/**
+ * Pins ValorCalculator's fixed and bonus valor before those methods are
+ * de-quadratified.
+ *
+ * calculateFixedValor() currently loads every daily_rankings row for the round
+ * and then filters that collection once per dominion; calculateBonusValor()
+ * does the same over the valor table. Both are being rewritten to aggregate in
+ * SQL, so these tests exist to prove the numbers do not move.
+ *
+ * The subtle one is testRealmZeroDominionScoresNothingForRankConqueredAndBounties:
+ * calculateFixedValor and calculateBreakdown look like twins but are not, and
+ * the difference is easy to erase by accident.
+ */
+#[CoversClass(ValorCalculator::class)]
+class ValorCalculatorTest extends AbstractTestCase
+{
+    private ValorCalculator $calculator;
+
+    private LandCalculator $landCalculator;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->calculator = $this->app->make(ValorCalculator::class);
+        $this->landCalculator = $this->app->make(LandCalculator::class);
+    }
+
+    public function testFixedValorCombinesRankLandConqueredAndBounties(): void
+    {
+        $round = $this->createRound('-7 days');
+
+        $first = $this->createDominion($this->createUser(), $round);
+        $second = $this->createDominion($this->createUser(), $round);
+
+        $this->seedRanking($first, 'largest-dominions', 900, 1);
+        $this->seedRanking($second, 'largest-dominions', 300, 2);
+        $this->seedRanking($first, 'total-land-conquered', 75, 1);
+        $this->seedRanking($second, 'total-land-conquered', 25, 2);
+        $this->seedRanking($first, 'bounties-collected', 40, 1);
+        $this->seedRanking($second, 'bounties-collected', 10, 2);
+
+        $valor = $this->calculator->calculateFixedValor($round, $this->collect([$first, $second]));
+
+        $totalLand = 1200;
+        $expectedFirst = 1000.0
+            + round(3000 / $totalLand * $this->landCalculator->getTotalLand($first), 2)
+            + round(1500 / 100 * 75, 2)
+            + round(1500 / 50 * 40, 2);
+        $expectedSecond = 500.0
+            + round(3000 / $totalLand * $this->landCalculator->getTotalLand($second), 2)
+            + round(1500 / 100 * 25, 2)
+            + round(1500 / 50 * 10, 2);
+
+        $this->assertEqualsWithDelta($expectedFirst, $valor[$first->id], 0.01);
+        $this->assertEqualsWithDelta($expectedSecond, $valor[$second->id], 0.01);
+    }
+
+    /**
+     * Rank feeds a non-linear step function, so this pins the exact shape:
+     * 1000 for rank 1, 500 for rank 2, then round(1250/rank)-5.
+     */
+    public function testLandRankValorFollowsTheFixedStepFunction(): void
+    {
+        $round = $this->createRound('-7 days');
+
+        $expectations = [1 => 1000.0, 2 => 500.0, 3 => 412.0, 10 => 120.0];
+        $dominions = [];
+
+        foreach ($expectations as $rank => $expected) {
+            $dominion = $this->createDominion($this->createUser(), $round);
+            $this->seedRanking($dominion, 'largest-dominions', 1000 - $rank, $rank);
+            $dominions[$rank] = $dominion;
+        }
+
+        $valor = $this->calculator->calculateFixedValor($round, $this->collect(array_values($dominions)));
+
+        foreach ($expectations as $rank => $expectedLandRankValor) {
+            // Only the land-rank component is asserted, so subtract the
+            // total-land share, which every dominion also earns.
+            $totalLand = array_sum(array_map(fn (int $r): int => 1000 - $r, array_keys($expectations)));
+            $totalLandValor = round(3000 / $totalLand * $this->landCalculator->getTotalLand($dominions[$rank]), 2);
+
+            $this->assertEqualsWithDelta(
+                $expectedLandRankValor + $totalLandValor,
+                $valor[$dominions[$rank]->id],
+                0.01,
+                "Rank {$rank} should be worth {$expectedLandRankValor} land-rank valor."
+            );
+        }
+    }
+
+    /**
+     * calculateFixedValor filters its ranking rows with realm_number != 0 and
+     * uses that same filtered set for the per-dominion lookups, so a dominion
+     * in the graveyard realm scores nothing for rank, conquered or bounties -
+     * while still earning its share of total land, which is read from the
+     * dominion itself rather than from a ranking row.
+     *
+     * calculateBreakdown() deliberately does NOT filter its per-dominion fetch
+     * this way. Do not "align" the two methods; this test is what catches it.
+     */
+    public function testRealmZeroRankingRowsAreIgnoredForTheirOwnDominion(): void
+    {
+        $round = $this->createRound('-7 days');
+
+        // The filter keys off the ranking row's realm_number, so the row is
+        // what needs to carry 0 - no graveyard realm required.
+        $buried = $this->createDominion($this->createUser(), $round);
+        $living = $this->createDominion($this->createUser(), $round);
+
+        $this->seedRanking($buried, 'largest-dominions', 5000, 1, 0);
+        $this->seedRanking($buried, 'total-land-conquered', 500, 1, 0);
+        $this->seedRanking($buried, 'bounties-collected', 500, 1, 0);
+        $this->seedRanking($living, 'largest-dominions', 100, 2);
+        $this->seedRanking($living, 'total-land-conquered', 50, 2);
+        $this->seedRanking($living, 'bounties-collected', 20, 2);
+
+        $valor = $this->calculator->calculateFixedValor($round, $this->collect([$buried, $living]));
+
+        // Only the total-land component survives, because that one is read
+        // from the dominion itself rather than from a ranking row. The
+        // denominator is 100 - the realm-0 row is excluded from it too.
+        $expectedBuried = round(3000 / 100 * $this->landCalculator->getTotalLand($buried), 2);
+
+        $this->assertEqualsWithDelta($expectedBuried, $valor[$buried->id], 0.01);
+    }
+
+    /**
+     * The realm_number != 0 filter also keeps graveyard rows out of the
+     * denominators, so a huge buried total must not dilute everyone else.
+     */
+    public function testRealmZeroRowsAreExcludedFromTheTotals(): void
+    {
+        $round = $this->createRound('-7 days');
+
+        $buried = $this->createDominion($this->createUser(), $round);
+        $living = $this->createDominion($this->createUser(), $round);
+
+        $this->seedRanking($living, 'total-land-conquered', 100, 1);
+        $valorWithoutGraveyard = $this->calculator->calculateFixedValor($round, $this->collect([$living]));
+
+        $this->seedRanking($buried, 'total-land-conquered', 900, 2, 0);
+        $valorWithGraveyard = $this->calculator->calculateFixedValor($round, $this->collect([$living]));
+
+        $this->assertEqualsWithDelta(
+            $valorWithoutGraveyard[$living->id],
+            $valorWithGraveyard[$living->id],
+            0.01,
+            'A graveyard row must not enter the total-land-conquered denominator.'
+        );
+    }
+
+    public function testMissingAndNullRanksScoreZeroLandRankValor(): void
+    {
+        $round = $this->createRound('-7 days');
+
+        $nullRank = $this->createDominion($this->createUser(), $round);
+        $noRow = $this->createDominion($this->createUser(), $round);
+
+        $this->seedRanking($nullRank, 'largest-dominions', 100, null);
+
+        $valor = $this->calculator->calculateFixedValor($round, $this->collect([$nullRank, $noRow]));
+
+        // A NULL rank scores zero land-rank valor rather than throwing, and
+        // both dominions still earn the total-land share - that component is
+        // computed from the dominion's own acreage, not from a ranking row.
+        $expectedNullRank = round(3000 / 100 * $this->landCalculator->getTotalLand($nullRank), 2);
+        $expectedNoRow = round(3000 / 100 * $this->landCalculator->getTotalLand($noRow), 2);
+
+        $this->assertEqualsWithDelta($expectedNullRank, $valor[$nullRank->id], 0.01);
+        $this->assertEqualsWithDelta($expectedNoRow, $valor[$noRow->id], 0.01);
+    }
+
+    public function testBonusValorSumsEveryValorSourceForTheDominion(): void
+    {
+        $round = $this->createRound('-7 days');
+
+        $dominion = $this->createDominion($this->createUser(), $round);
+        $other = $this->createDominion($this->createUser(), $round);
+
+        $this->seedValor($dominion, 'war_hit', 120.5);
+        $this->seedValor($dominion, 'largest_hit', 80.0);
+        $this->seedValor($dominion, 'wonder', 40.25);
+        $this->seedValor($other, 'war_hit', 999.0);
+
+        $bonus = $this->calculator->calculateBonusValor($round, $this->collect([$dominion, $other]));
+
+        $this->assertEqualsWithDelta(240.75, $bonus[$dominion->id], 0.01);
+        $this->assertEqualsWithDelta(999.0, $bonus[$other->id], 0.01);
+    }
+
+    public function testBonusValorIsZeroWithoutValorRows(): void
+    {
+        $round = $this->createRound('-7 days');
+        $dominion = $this->createDominion($this->createUser(), $round);
+
+        $bonus = $this->calculator->calculateBonusValor($round, $this->collect([$dominion]));
+
+        $this->assertEqualsWithDelta(0.0, $bonus[$dominion->id], 0.01);
+    }
+
+    /**
+     * The assertion that actually locks the optimisation in. A future refactor
+     * reintroducing a per-dominion query fails here rather than silently at a
+     * thousand dominions.
+     */
+    /**
+     * The invariant is that the query count is CONSTANT in the number of
+     * dominions, not that it equals any particular number - aggregating the
+     * totals separately legitimately changes one query into two. Asserting the
+     * absolute would just pin whichever implementation happened to be current.
+     */
+    public function testFixedValorQueryCountDoesNotGrowWithDominionCount(): void
+    {
+        $round = $this->createRound('-7 days');
+
+        $few = $this->buildRankedDominions($round, 2);
+        $withFew = $this->countRankingQueries($round, $few);
+
+        $many = $this->buildRankedDominions($round, 12);
+        $withMany = $this->countRankingQueries($round, $many);
+
+        $this->assertSame(
+            $withFew,
+            $withMany,
+            'calculateFixedValor must issue the same number of daily_rankings queries for 2 dominions as for 12.'
+        );
+        $this->assertLessThan(5, $withMany, 'Constant, but it should also be a small constant.');
+    }
+
+    public function testBonusValorQueryCountDoesNotGrowWithDominionCount(): void
+    {
+        $round = $this->createRound('-7 days');
+
+        $few = $this->buildRankedDominions($round, 2);
+        $withFew = $this->countValorQueries($round, $few);
+
+        $many = $this->buildRankedDominions($round, 12);
+        $withMany = $this->countValorQueries($round, $many);
+
+        $this->assertSame(
+            $withFew,
+            $withMany,
+            'calculateBonusValor must issue the same number of valor queries for 2 dominions as for 12.'
+        );
+        $this->assertLessThan(5, $withMany, 'Constant, but it should also be a small constant.');
+    }
+
+    /**
+     * @param array<int, Dominion> $dominions
+     */
+    private function collect(array $dominions): EloquentCollection
+    {
+        return new EloquentCollection($dominions);
+    }
+
+    private function buildRankedDominions(Round $round, int $count): EloquentCollection
+    {
+        $dominions = [];
+
+        for ($i = 0; $i < $count; $i++) {
+            $dominion = $this->createDominion($this->createUser(), $round);
+            $this->seedRanking($dominion, 'largest-dominions', 1000 - $i, $i + 1);
+            $this->seedValor($dominion, 'war_hit', 10.0);
+            $dominions[] = $dominion;
+        }
+
+        return $this->collect($dominions);
+    }
+
+    private function countRankingQueries(Round $round, EloquentCollection $dominions): int
+    {
+        return $this->countQueriesMatching('daily_rankings', function () use ($round, $dominions): void {
+            $this->calculator->calculateFixedValor($round, $dominions);
+        });
+    }
+
+    private function countValorQueries(Round $round, EloquentCollection $dominions): int
+    {
+        return $this->countQueriesMatching('`valor`', function () use ($round, $dominions): void {
+            $this->calculator->calculateBonusValor($round, $dominions);
+        });
+    }
+
+    /**
+     * Reuses the profiler that backs the benchmark suite and dev:tick:profile.
+     */
+    private function countQueriesMatching(string $fragment, callable $callback): int
+    {
+        $profiler = new QueryProfilerService();
+
+        $profiler->start();
+        $callback();
+        $queries = $profiler->stop();
+
+        $matches = 0;
+
+        foreach ($queries as $query) {
+            if (stripos($query['sql'], $fragment) !== false) {
+                $matches++;
+            }
+        }
+
+        return $matches;
+    }
+
+    private function seedRanking(Dominion $dominion, string $key, int $value, ?int $rank, ?int $realmNumber = null): void
+    {
+        DailyRanking::create([
+            'round_id' => $dominion->round_id,
+            'dominion_id' => $dominion->id,
+            'dominion_name' => $dominion->name,
+            'race_name' => $dominion->race->name,
+            'realm_number' => $realmNumber ?? $dominion->realm->number,
+            'realm_name' => $dominion->realm->name,
+            'key' => $key,
+            'value' => $value,
+            'rank' => $rank,
+        ]);
+    }
+
+    private function seedValor(Dominion $dominion, string $source, float $amount): void
+    {
+        Valor::create([
+            'round_id' => $dominion->round_id,
+            'realm_id' => $dominion->realm_id,
+            'dominion_id' => $dominion->id,
+            'source' => $source,
+            'amount' => $amount,
+        ]);
+    }
+}

--- a/tests/Unit/Models/DominionPerkResolutionTest.php
+++ b/tests/Unit/Models/DominionPerkResolutionTest.php
@@ -1,0 +1,301 @@
+<?php
+
+namespace OpenDominion\Tests\Unit\Models;
+
+use Illuminate\Support\Collection;
+use OpenDominion\Models\Dominion;
+use OpenDominion\Models\Spell;
+use OpenDominion\Models\Tech;
+use OpenDominion\Tests\AbstractTestCase;
+use ReflectionProperty;
+
+/**
+ * Guards the memoized perk resolution on Dominion.
+ *
+ * Two things are being protected here:
+ *
+ *  1. That memoizing did not change any answer. getSpellPerkValue and
+ *     getTechPerkValue were rewritten to read from a grouped structure built
+ *     once per relation load instead of rebuilding a collection on every call.
+ *     The tests below recompute every value the way the old implementation did
+ *     and demand an exact match, across every perk key in the seeded game data.
+ *
+ *  2. That the memo dies with the relation it describes. There is no manual
+ *     invalidation call anywhere - correctness depends entirely on the
+ *     setRelation/unsetRelation/setRelations/unsetRelations/__clone overrides
+ *     firing, so each is tested directly.
+ */
+class DominionPerkResolutionTest extends AbstractTestCase
+{
+    /**
+     * The distinct $types arrays actually passed to getSpellPerkValue anywhere
+     * in src/, including the five single-category lookups that
+     * SpellCalculator::resolveSpellPerk makes.
+     *
+     * @var array<int, array<int, string>>
+     */
+    private const TYPE_SETS = [
+        ['self', 'friendly'],
+        ['self'],
+        ['hostile'],
+        ['war'],
+        ['friendly'],
+        ['effect'],
+        ['self', 'friendly', 'effect'],
+        ['self', 'friendly', 'hostile', 'war'],
+    ];
+
+    public function testSpellPerkValueMatchesPreviousImplementationForEveryKeyAndTypeSet(): void
+    {
+        $dominion = $this->dominionWithEverySpell();
+
+        $keys = $this->allSpellPerkKeys($dominion);
+        $this->assertNotEmpty($keys, 'Expected the seeded game data to contain spell perks.');
+
+        $comparisons = 0;
+
+        foreach ($keys as $key) {
+            foreach (self::TYPE_SETS as $types) {
+                $this->assertSame(
+                    $this->legacySpellPerkValue($dominion, $key, $types),
+                    $dominion->getSpellPerkValue($key, $types),
+                    sprintf('Spell perk "%s" for types [%s] changed value.', $key, implode(', ', $types))
+                );
+
+                $comparisons++;
+            }
+        }
+
+        // A miscounted fixture that silently resolves nothing would pass every
+        // assertion above, so assert the comparison actually had breadth.
+        $this->assertGreaterThan(100, $comparisons);
+    }
+
+    /**
+     * The non-stacking rule flips from max to min when the max is negative.
+     * That branch only runs for a key whose values are all below zero, so it is
+     * worth proving the fixture reaches it rather than assuming.
+     */
+    public function testNegativeValuedSpellPerkStillResolvesThroughTheMinBranch(): void
+    {
+        $dominion = $this->dominionWithEverySpell();
+
+        $negativeKey = null;
+
+        foreach ($this->allSpellPerkKeys($dominion) as $key) {
+            if ($this->legacySpellPerkValue($dominion, $key, ['self', 'friendly']) < 0) {
+                $negativeKey = $key;
+                break;
+            }
+        }
+
+        if ($negativeKey === null) {
+            $this->markTestSkipped('No negative-valued spell perk in the seeded data.');
+        }
+
+        $this->assertSame(
+            $this->legacySpellPerkValue($dominion, $negativeKey, ['self', 'friendly']),
+            $dominion->getSpellPerkValue($negativeKey, ['self', 'friendly'])
+        );
+    }
+
+    public function testUnknownSpellPerkKeyResolvesToZero(): void
+    {
+        $dominion = $this->dominionWithEverySpell();
+
+        $this->assertSame(0.0, $dominion->getSpellPerkValue('this_perk_does_not_exist'));
+    }
+
+    public function testTechPerkValueMatchesPreviousImplementationForEveryKey(): void
+    {
+        $dominion = $this->dominionWithEveryTech();
+
+        $legacy = $dominion->techs
+            ->flatMap(static function (Tech $tech): Collection {
+                return $tech->perks;
+            })
+            ->groupBy('key');
+
+        $this->assertNotEmpty($legacy, 'Expected the seeded game data to contain tech perks.');
+
+        foreach ($legacy as $key => $perks) {
+            $this->assertSame(
+                (float)$perks->sum('pivot.value'),
+                $dominion->getTechPerkValue((string)$key),
+                sprintf('Tech perk "%s" changed value.', $key)
+            );
+        }
+    }
+
+    public function testUnsetRelationInvalidatesTheCache(): void
+    {
+        $dominion = $this->dominionWithEverySpell();
+        $key = $this->firstResolvingSpellPerkKey($dominion);
+
+        $this->assertNotSame(0.0, $dominion->getSpellPerkValue($key, ['self', 'friendly']));
+
+        $dominion->unsetRelation('spells');
+        $dominion->setRelation('spells', collect([]));
+
+        $this->assertSame(0.0, $dominion->getSpellPerkValue($key, ['self', 'friendly']));
+    }
+
+    public function testSetRelationInvalidatesTheCache(): void
+    {
+        $dominion = $this->dominionWithEverySpell();
+        $key = $this->firstResolvingSpellPerkKey($dominion);
+
+        $this->assertNotSame(0.0, $dominion->getSpellPerkValue($key, ['self', 'friendly']));
+
+        $dominion->setRelation('spells', collect([]));
+
+        $this->assertSame(0.0, $dominion->getSpellPerkValue($key, ['self', 'friendly']));
+    }
+
+    /**
+     * setRelations() and unsetRelations() assign $this->relations directly and
+     * never call setRelation(), so they need their own hooks. Missing these is
+     * the usual hole in this pattern.
+     */
+    public function testBulkRelationMutatorsInvalidateTheCache(): void
+    {
+        $dominion = $this->dominionWithEverySpell();
+        $key = $this->firstResolvingSpellPerkKey($dominion);
+
+        $dominion->getSpellPerkValue($key, ['self', 'friendly']);
+        $dominion->setRelations(['spells' => collect([])]);
+        $this->assertSame(0.0, $dominion->getSpellPerkValue($key, ['self', 'friendly']));
+
+        $dominion = $this->dominionWithEverySpell();
+        $dominion->getSpellPerkValue($key, ['self', 'friendly']);
+        $dominion->unsetRelations();
+        $dominion->setRelation('spells', collect([]));
+        $this->assertSame(0.0, $dominion->getSpellPerkValue($key, ['self', 'friendly']));
+    }
+
+    /**
+     * PHP's shallow clone would otherwise hand the copy a cache describing the
+     * original's relations. DominionSaved clones a dominion and then reloads
+     * relations on the copy, which is exactly this situation.
+     */
+    public function testCloneStartsWithAnEmptyCache(): void
+    {
+        $dominion = $this->dominionWithEverySpell();
+        $key = $this->firstResolvingSpellPerkKey($dominion);
+
+        $dominion->getSpellPerkValue($key, ['self', 'friendly']);
+        $this->assertNotNull($this->readCache($dominion), 'Expected the original to have a populated cache.');
+
+        $clone = clone $dominion;
+
+        $this->assertNull($this->readCache($clone), 'Clone inherited the original perk cache.');
+        $this->assertNotNull($this->readCache($dominion), 'Cloning must not disturb the original.');
+    }
+
+    /**
+     * The cache is not keyed on the dominion id, and this is why: the
+     * calculations page builds a Dominion that has never been saved.
+     */
+    public function testUnsavedDominionsResolveIndependently(): void
+    {
+        $withSpells = $this->dominionWithEverySpell();
+        $key = $this->firstResolvingSpellPerkKey($withSpells);
+
+        $unsaved = new Dominion();
+        $unsaved->setRelation('spells', collect([]));
+
+        $this->assertNull($unsaved->id);
+        $this->assertSame(0.0, $unsaved->getSpellPerkValue($key, ['self', 'friendly']));
+        $this->assertNotSame(0.0, $withSpells->getSpellPerkValue($key, ['self', 'friendly']));
+    }
+
+    /**
+     * Reproduces the pre-memoization algorithm exactly, using the retained (now
+     * deprecated) getSpellPerks() as its input.
+     */
+    private function legacySpellPerkValue(Dominion $dominion, string $key, array $types): float
+    {
+        $perks = $dominion->getSpellPerks()->whereIn('category', $types)->groupBy('key');
+
+        if (isset($perks[$key])) {
+            if ($perks[$key]->count() == 1) {
+                return $perks[$key]->first()->pivot->value;
+            }
+
+            $perkValue = (float)$perks[$key]->max('pivot.value');
+
+            if ($perkValue < 0) {
+                $perkValue = (float)$perks[$key]->min('pivot.value');
+            }
+
+            return $perkValue;
+        }
+
+        return 0;
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    private function allSpellPerkKeys(Dominion $dominion): array
+    {
+        return $dominion->getSpellPerks()
+            ->pluck('key')
+            ->unique()
+            ->values()
+            ->all();
+    }
+
+    private function firstResolvingSpellPerkKey(Dominion $dominion): string
+    {
+        foreach ($this->allSpellPerkKeys($dominion) as $key) {
+            if ($this->legacySpellPerkValue($dominion, $key, ['self', 'friendly']) != 0.0) {
+                return $key;
+            }
+        }
+
+        $this->fail('No spell perk in the seeded data resolves to a non-zero self/friendly value.');
+    }
+
+    /**
+     * Attaches every spell that carries perks, so the comparison covers every
+     * category present in the game data - including keys that appear under more
+     * than one category, which is where grouping could go wrong.
+     */
+    private function dominionWithEverySpell(): Dominion
+    {
+        $dominion = $this->createDominionWithLegacyStats($this->createUser(), $this->createRound('-7 days'));
+
+        $attachments = Spell::has('perks')->pluck('id')->mapWithKeys(
+            static function (int $spellId): array {
+                return [$spellId => ['duration' => 12]];
+            }
+        )->all();
+
+        $dominion->spells()->attach($attachments);
+        $dominion->load(['spells', 'spells.perks']);
+
+        return $dominion;
+    }
+
+    private function dominionWithEveryTech(): Dominion
+    {
+        $dominion = $this->createDominionWithLegacyStats($this->createUser(), $this->createRound('-7 days'));
+
+        $dominion->techs()->syncWithoutDetaching(Tech::has('perks')->pluck('id')->all());
+        $dominion->load(['techs', 'techs.perks']);
+
+        return $dominion;
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    private function readCache(Dominion $dominion): ?array
+    {
+        $property = new ReflectionProperty(Dominion::class, 'spellPerksByCategory');
+        $property->setAccessible(true);
+
+        return $property->getValue($dominion);
+    }
+}

--- a/tests/Unit/Services/Dominion/DailyRankingsTest.php
+++ b/tests/Unit/Services/Dominion/DailyRankingsTest.php
@@ -1,0 +1,306 @@
+<?php
+
+namespace OpenDominion\Tests\Unit\Services\Dominion;
+
+use DB;
+use OpenDominion\Models\Dominion;
+use OpenDominion\Models\Round;
+use OpenDominion\Services\Dominion\TickService;
+use OpenDominion\Tests\AbstractTestCase;
+
+/**
+ * Pins the rank values produced by TickService::updateDailyRankings().
+ *
+ * Nothing asserted these before, and they are load-bearing: ValorCalculator's
+ * getFixedValorLandRank() is non-linear in the rank integer (1000 for rank 1,
+ * 500 for rank 2, round(1250/rank)-5 beyond), and RaidCalculator,
+ * RankingsService, ValhallaController and MessageBoardController all branch on
+ * rank == 1 - where a tie currently means every tied leader wins.
+ *
+ * These tests were written against the original COUNT(b.value)+1 self-join and
+ * must keep passing UNCHANGED through any rewrite of it. If one needs editing,
+ * the rewrite changed behaviour.
+ *
+ * Note updateDailyRankings() takes no round argument: it processes every round
+ * matching Round::activeRankings() whose start_date hour equals the current
+ * hour. Every assertion here is therefore scoped to the ids this test created,
+ * so leftover rounds in a shared dev database cannot affect the result.
+ */
+class DailyRankingsTest extends AbstractTestCase
+{
+    private TickService $tickService;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->tickService = $this->app->make(TickService::class);
+    }
+
+    /**
+     * The distinguishing test. RANK() shares a rank across ties and then skips,
+     * DENSE_RANK() would not skip, and ROW_NUMBER() would not tie at all.
+     */
+    public function testTiesShareARankAndCreateAGap(): void
+    {
+        $round = $this->createRankableRound();
+        [$first, $tied, $third, $fourth] = $this->createDominionsWithPrestige($round, [300, 300, 200, 100]);
+
+        $this->tickService->updateDailyRankings();
+
+        $ranks = $this->storedRanks($round, 'prestige');
+
+        $this->assertSame(1, $ranks[$first->id]);
+        $this->assertSame(1, $ranks[$tied->id]);
+        $this->assertSame(3, $ranks[$third->id], 'The value after a two-way tie must skip to rank 3.');
+        $this->assertSame(4, $ranks[$fourth->id]);
+
+        $this->assertNotContains(2, $ranks, 'A tie at rank 1 must leave rank 2 unused.');
+    }
+
+    public function testPreviousRankIsNullOnTheFirstRun(): void
+    {
+        $round = $this->createRankableRound();
+        [$dominion] = $this->createDominionsWithPrestige($round, [300]);
+
+        $this->tickService->updateDailyRankings();
+
+        $row = $this->rankingRow($dominion, 'prestige');
+
+        $this->assertSame(1, (int)$row->rank);
+        $this->assertNull($row->previous_rank);
+    }
+
+    /**
+     * previous_rank must carry the rank as it stood BEFORE this run. This is
+     * what breaks if a rewrite assigns it from the live column inside a
+     * multi-table UPDATE, where assignment order is not guaranteed.
+     */
+    public function testPreviousRankCarriesTheRankFromTheRunBefore(): void
+    {
+        $round = $this->createRankableRound();
+        [$alpha, $beta] = $this->createDominionsWithPrestige($round, [300, 100]);
+
+        $this->tickService->updateDailyRankings();
+
+        $this->assertSame(1, (int)$this->rankingRow($alpha, 'prestige')->rank);
+        $this->assertSame(2, (int)$this->rankingRow($beta, 'prestige')->rank);
+
+        // Swap their standing and rank again.
+        $this->setPrestige($alpha, 100);
+        $this->setPrestige($beta, 300);
+
+        $this->tickService->updateDailyRankings();
+
+        $alphaRow = $this->rankingRow($alpha, 'prestige');
+        $betaRow = $this->rankingRow($beta, 'prestige');
+
+        $this->assertSame(2, (int)$alphaRow->rank);
+        $this->assertSame(1, (int)$alphaRow->previous_rank);
+
+        $this->assertSame(1, (int)$betaRow->rank);
+        $this->assertSame(2, (int)$betaRow->previous_rank);
+    }
+
+    /**
+     * The ranking window partitions by key only - the round is a filter. This
+     * is the test that catches dropping that filter from either side of a
+     * rewritten statement.
+     */
+    public function testRanksAreScopedToTheirOwnRound(): void
+    {
+        $roundOne = $this->createRankableRound('-7 days');
+        $roundTwo = $this->createRankableRound('-3 days');
+
+        [$smallFirst, $smallSecond] = $this->createDominionsWithPrestige($roundOne, [100, 50]);
+        [$bigFirst, $bigSecond] = $this->createDominionsWithPrestige($roundTwo, [10000, 9000]);
+
+        $this->tickService->updateDailyRankings();
+
+        $roundOneRanks = $this->storedRanks($roundOne, 'prestige');
+        $roundTwoRanks = $this->storedRanks($roundTwo, 'prestige');
+
+        $this->assertSame(1, $roundOneRanks[$smallFirst->id], 'A far larger dominion in another round must not outrank this one.');
+        $this->assertSame(2, $roundOneRanks[$smallSecond->id]);
+
+        $this->assertSame(1, $roundTwoRanks[$bigFirst->id]);
+        $this->assertSame(2, $roundTwoRanks[$bigSecond->id]);
+    }
+
+    /**
+     * Catches a dropped PARTITION BY key: the same dominions must rank
+     * independently under each ranking key.
+     */
+    public function testRanksArePerKeyIndependent(): void
+    {
+        $round = $this->createRankableRound();
+        [$one, $two, $three] = $this->createDominionsWithPrestige($round, [300, 200, 100]);
+
+        // Invert the land ordering relative to prestige.
+        $this->setLand($one, 100);
+        $this->setLand($two, 500);
+        $this->setLand($three, 900);
+
+        $this->tickService->updateDailyRankings();
+
+        $prestigeRanks = $this->storedRanks($round, 'prestige');
+        $landRanks = $this->storedRanks($round, 'largest-dominions');
+
+        $this->assertSame([1, 2, 3], [$prestigeRanks[$one->id], $prestigeRanks[$two->id], $prestigeRanks[$three->id]]);
+        $this->assertSame([3, 2, 1], [$landRanks[$one->id], $landRanks[$two->id], $landRanks[$three->id]]);
+    }
+
+    /**
+     * A locked dominion has its value forced to zero but still receives a row
+     * and a rank, placing it last rather than removing it from the ladder.
+     */
+    public function testZeroedOutDominionsAreStillRanked(): void
+    {
+        $round = $this->createRankableRound();
+        [$active, $locked] = $this->createDominionsWithPrestige($round, [300, 500]);
+
+        DB::table('dominions')->where('id', $locked->id)->update(['locked_at' => now()]);
+
+        $this->tickService->updateDailyRankings();
+
+        $lockedRow = $this->rankingRow($locked, 'prestige');
+
+        $this->assertSame(0, (int)$lockedRow->value, 'A locked dominion must have its value zeroed.');
+        $this->assertSame(2, (int)$lockedRow->rank, 'It must still be ranked, behind the active dominion.');
+        $this->assertSame(1, (int)$this->rankingRow($active, 'prestige')->rank);
+    }
+
+    /**
+     * The equivalence proof: every stored rank must match what the original
+     * self-join computes from the same stored values, across every key, with a
+     * spread chosen to produce heavy ties.
+     */
+    public function testStoredRanksMatchTheLegacySelfJoinAcrossEveryKey(): void
+    {
+        $round = $this->createRankableRound();
+        $this->createDominionsWithPrestige($round, [500, 500, 500, 250, 250, 100, 1]);
+
+        $this->tickService->updateDailyRankings();
+
+        $expected = $this->legacyRanks($round);
+        $actual = $this->storedRanksByKey($round);
+
+        $this->assertNotEmpty($expected, 'Expected the round to have produced ranking rows.');
+        $this->assertEquals($expected, $actual);
+    }
+
+    /**
+     * A round whose start_date hour matches the current hour, which is what
+     * updateDailyRankings() gates on.
+     */
+    private function createRankableRound(string $startDate = '-7 days'): Round
+    {
+        return $this->createRound($startDate);
+    }
+
+    /**
+     * @param array<int, int> $prestigeValues
+     * @return array<int, Dominion>
+     */
+    private function createDominionsWithPrestige(Round $round, array $prestigeValues): array
+    {
+        $dominions = [];
+
+        foreach ($prestigeValues as $prestige) {
+            $dominion = $this->createDominion($this->createUser(), $round);
+            $this->setPrestige($dominion, $prestige);
+            $dominions[] = $dominion;
+        }
+
+        return $dominions;
+    }
+
+    /**
+     * Written straight to the database rather than through the model, so the
+     * DominionSaved listener does not run a networth calculation and a tick
+     * pre-calculation for every fixture row.
+     */
+    private function setPrestige(Dominion $dominion, int $prestige): void
+    {
+        DB::table('dominions')->where('id', $dominion->id)->update(['prestige' => $prestige]);
+    }
+
+    private function setLand(Dominion $dominion, int $landPlain): void
+    {
+        DB::table('dominions')->where('id', $dominion->id)->update(['land_plain' => $landPlain]);
+    }
+
+    private function rankingRow(Dominion $dominion, string $key): object
+    {
+        $row = DB::table('daily_rankings')
+            ->where('dominion_id', $dominion->id)
+            ->where('key', $key)
+            ->first();
+
+        $this->assertNotNull($row, "Expected a '{$key}' ranking row for dominion {$dominion->id}.");
+
+        return $row;
+    }
+
+    /**
+     * @return array<int, int> dominion id => rank
+     */
+    private function storedRanks(Round $round, string $key): array
+    {
+        return DB::table('daily_rankings')
+            ->where('round_id', $round->id)
+            ->where('key', $key)
+            ->get(['dominion_id', 'rank'])
+            ->mapWithKeys(static function (object $row): array {
+                return [(int)$row->dominion_id => (int)$row->rank];
+            })
+            ->all();
+    }
+
+    /**
+     * @return array<string, int> "dominionId:key" => rank
+     */
+    private function storedRanksByKey(Round $round): array
+    {
+        $ranks = DB::table('daily_rankings')
+            ->where('round_id', $round->id)
+            ->get(['dominion_id', 'key', 'rank'])
+            ->mapWithKeys(static function (object $row): array {
+                return ["{$row->dominion_id}:{$row->key}" => (int)$row->rank];
+            })
+            ->all();
+
+        ksort($ranks);
+
+        return $ranks;
+    }
+
+    /**
+     * The pre-rewrite ranking expression, kept verbatim as the reference
+     * implementation. Do not "modernise" this - its whole value is being the
+     * thing the new implementation must agree with.
+     *
+     * @return array<string, int> "dominionId:key" => rank
+     */
+    private function legacyRanks(Round $round): array
+    {
+        $ranks = DB::table('daily_rankings AS a')
+            ->select(DB::raw('a.dominion_id, a.`key` AS ranking_key, COUNT(b.value)+1 AS legacy_rank'))
+            ->leftJoin('daily_rankings AS b', function ($join) use ($round) {
+                $join->on('a.value', '<', 'b.value');
+                $join->on('a.key', '=', 'b.key');
+                $join->where('b.round_id', $round->id);
+            })
+            ->where('a.round_id', $round->id)
+            ->groupBy('a.dominion_id', 'a.key', 'a.value')
+            ->get()
+            ->mapWithKeys(static function (object $row): array {
+                return ["{$row->dominion_id}:{$row->ranking_key}" => (int)$row->legacy_rank];
+            })
+            ->all();
+
+        ksort($ranks);
+
+        return $ranks;
+    }
+}


### PR DESCRIPTION
## Summary

The hourly tick was the heaviest thing this application does, and it was running on two `Log::info` timings. This branch first builds the means to measure it, then optimises what the measurements actually pointed at — which repeatedly turned out not to be what static analysis predicted.

Everything here is guarded by benchmark tests with hard budgets, so the gains can't be quietly given back.

## Results

CI-enforced budgets (`tests/Benchmark`, N=40 fixture):

| Metric | Before | After |
|---|---|---|
| Queries per dominion | 31.57 | **21.23** |
| Marginal queries per additional dominion | 30.90 | **20.47** |
| `precalculateTick()`, one dominion | 19 | **16** |
| `performTick($round, $dominion)`, cold relations | 61 | **49** |
| Most-repeated statement, per dominion | 6.10 | **1.20** |
| Phase A bulk statements | 3 | 3 (protected) |

Real-scale profiling (`dev:tick:profile`, 480 dominions, rolled back):

| Metric | Before | After |
|---|---|---|
| Wall time per dominion | 58.99 ms | **24.82 ms** |
| Queries per dominion | 31.15 | **20.77** |
| Peak memory | 221 MB | **96.5 MB** |
| Daily-rankings self-join | 365.3 ms | **16.5 ms** |
| …its growth per 4× dominions | 15.3× (quadratic) | **1.8×** |

Extrapolated to ~1,500 dominions, the tick goes from roughly 88 s to under 20 s.

**A latent hard failure is also closed.** The daily-rankings rank upsert bound `rows × 13` placeholders against MySQL's 65,535 protocol ceiling — a hard cap of 5,041 rows, or roughly 500 dominions at 10 populated ranking keys. Past that the tick would have thrown inline. The replacement binds two integers regardless of N.

## What changed

**Query volume.** The tick's eager load pulled `spells` but not `spells.perks` (while pulling `techs.perks` two lines below), so the first perk lookup lazily loaded perks once per active spell per dominion. One line, ~19% of all queries. A discarded `getActiveSpells()` call — a no-op since 2021 — went too, along with a dead `with('dominions')` in `tickDaily()` and two cleanup DELETEs that matched no rows on most dominions.

**PHP time.** Perk resolution rebuilt a collection on every lookup; it now memoizes a category-keyed map on `Dominion`, invalidated through the relation mutators. `Round::findCached()` was re-reading the file cache once per dominion for what is the same round — 39.8% of the tick's PHP time, now 0.2%. The tick-value reset loop went from ~80 cast-machinery writes per dominion to one raw assignment. Pulse no longer inspects every one of ~7,700 queries during a scheduled command nobody browses.

**The quadratic.** The daily-rankings rank was a `COUNT(b.value)+1` self-join with no supporting index. It is now `RANK() OVER (PARTITION BY key ORDER BY value DESC)` applied by a single server-side UPDATE, plus a covering index. `ValorCalculator` had a second quadratic in PHP — filtering a collection of every ranking row once per dominion — and a third in `calculateBonusValor`; both now aggregate in SQL.

**Correctness insurance.** `withoutOverlapping(120)` on the schedule, so a tick running long can't have a second one apply Phase A's deltas twice.

## Measurement is the point

Three times, careful static reasoning pointed at the wrong thing, and only measurement caught it:

- Stage 0 was planned around perk memoization. The dominant cost was the missing `spells.perks` eager load — a one-liner nobody had suspected.
- The benchmark fixture itself was inflating per-dominion cost ~2×, because "seed the spells with the most perks" happened to select one that triggers a `performSpellEffects` special case on every dominion.
- Stage 4's ranked suspect list (QueueService allocations, population fan-out, wonder perks) turned out to be noise — `QueueService` is 1.5%. The real answer, 39.8%, was file-cache reads, which appeared nowhere on that list.

Hence the tooling in this branch, and hence the budgets.

## Commit guide

| Commit | What it does |
|---|---|
| `d6952c5` | Two static-analysis reports that seeded the work. Kept for provenance — several of their conclusions were later corrected by measurement, and the corrections are noted in the budget file. |
| `d287fd7` | The benchmark harness: query capture and attribution (`TickProfiler`/`TickProfile`), a deterministic fixture builder (`BenchmarkRoundSeeder`), and a report-only baseline test. Adds a `Benchmark` testsuite, excluded from default runs by group. |
| `5603bcd` | `phase0_headline.md`, the first measured baseline. Carries a superseded notice — see `4b565d1`. |
| `29312ba` | Hard budgets (`TickBenchmarkBudgets`) and the assertion suite; shared harness extracted to `AbstractTickBenchmarkTestCase`. |
| `4b565d1` | Per-finding tests, plus the fixture correction that revealed the earlier numbers were ~2× too high. |
| `98384e3` | `dev:tick:profile` and `QueryProfilerService`, shared by the command and the test harness so both normalise SQL identically and their numbers are comparable. |
| `3b8434f` | Perk-resolution differential test (739 assertions proving old and new agree across every seeded perk key), budget ratchets, and a fix for `dev:seed:realms`, which picked races without matching realm alignment and so always threw. |
| `074eb91` | **Game code, stages 0–1.** `spells.perks` eager load, perk memoization on `Dominion`, dead `getActiveSpells()` removal, duplicated production hoists, bit-rotted console guard, `withoutOverlapping`. |
| `f22e6e4` | Characterization tests for rankings and Valor, written against unmodified code so they serve as an equivalence oracle rather than a description of the new implementation. |
| `0bbe29a` | **Game code, stage 2.** `RANK()` window function, covering-index migration, and the Valor de-quadratification. |
| `20e1724` | Benchmark Docker image (excimer + xdebug, both off by default) and a dedicated benchmark database, behind a compose profile so default `up` is unchanged. |
| `db2a8d3` | Captured folded stacks from the baseline profile. Pure artifact — say the word and I'll drop it from the branch. |
| `e4d6327` | **Game code, stage 3.** `Round::findCached` memo, raw tick-value reset, Pulse disabled during the tick, cleanup N+1 and empty-DELETE fixes. |

## Verification

```bash
docker compose up -d
php artisan migrate                      # adds the daily_rankings covering index

./vendor/bin/phpunit --group=benchmark   # budgets; excluded from default runs
./vendor/bin/phpunit --testsuite=Feature
./vendor/bin/phpunit --testsuite=Http
./vendor/bin/phpunit tests/Unit/Calculators tests/Unit/Models tests/Unit/Factories
./vendor/bin/phpunit tests/Unit/Services
```

All green: 12 benchmark, 101 Feature, 39 Http, 253 unit calculators/models/factories, 185 unit services. **No existing test needed editing** — that was the acceptance criterion for the two behaviour-preserving refactors (perk resolution and the rank rewrite), and it held.

Real-scale profiling:

```bash
docker compose --profile benchmark up -d mariadb-benchmark
docker compose run --rm benchmark php artisan migrate --force
docker compose run --rm benchmark php artisan db:seed --force
docker compose run --rm benchmark php artisan game:data:sync
docker compose run --rm benchmark php artisan dev:seed:realms --count=60
docker compose run --rm benchmark php artisan dev:tick:profile --sample
```

`--sample` attributes PHP time to functions via excimer; `--collapsed=<relative path>` writes flamegraph-ready folded stacks. Rollback is the default, so nothing is kept.

## Further improvements, not in this PR

Ranked by wall-clock impact:

1. **Enable JIT — ~17%, no code change.** Measured across three paired runs: `opcache.enable_cli=1` with `opcache.jit=tracing` takes the tick from ~6,700 ms to ~5,560 ms at N=480, and collapses run-to-run variance from a 1,400 ms spread to 250 ms. OPcache alone does nothing (a single run compiles once anyway); the win is tracing JIT over a loop that runs the same calculator paths hundreds of times. Open question is only where to put the setting.
2. **Parallelise phase B — potentially 2–3×.** Phase A is already three bulk statements; everything after is a per-dominion loop over independent rows. Splitting it across 3–4 worker processes is the only remaining lever that changes the order of magnitude. Complications: `performSpellEffects` and `performRaceUnitProduction` are round-wide and must stay in the parent, deadlock risk rises, and `ext-pcntl` isn't in the image (so `Process::pool()` rather than fork).
3. **Batch the remaining per-dominion queries — ~20%.** Measured round-trip floor is 0.122 ms against a 0.361 ms average, so a third of database time is pure latency that disappears with the query. Targets: the relation reload (`techs`/`heroes`/`realms`/`wonders`/`dominions` refetch, ~865 ms — `realm.wonders` alone is fetched 480 times for 40 realms), the `dominion_tick` upsert (~240 ms), and the `dominion_history` inserts (~190 ms). The relation reload is the risky one: it touches the guard protecting the action-request path.
4. **Smaller, measured:** `getDominionNetworth` at 7.1% (called with `$fresh = true`, bypassing its own cache), the two cleanups at ~12% combined (batching blocked by `NotificationService` being a singleton keyed only by notification type), `HistoryService::record` at 3.8%, and `ValorCalculator::calculate()`'s per-realm N+1 (60 queries, once daily).
5. **`Race::findWithRelationsCached`** deserves the same memo as `Round`. It contributes nothing to the tick but sits on the web request path.

## Known gaps and caveats

- **Commit cost and lock contention were never measured.** Every number here comes from inside a rolled-back transaction, which turns the tick's own transactions into savepoints. This is the one original finding still resting purely on static analysis, and it's the one that determines whether players see *"The Emperor is currently collecting taxes"*. Needs `dev:tick:profile --commit`.
- **Unprofiled paths:** everything in `tickHourly()` other than `performTick()` (hero battles, tournaments, raids, valuables), the NPD-generation hour, and the web request path.
- **Two fixtures, two sets of numbers.** The PHPUnit fixture deliberately seeds expiring spells and special-case spells; `dev:seed:realms` does not. They exercise genuinely different paths and are not interchangeable — compare like with like.
- **The benchmark database is for profiling, not tests.** It's expected to hold a large persistent round, and `UserFactory`'s `faker->unique()` only dedupes within one process, so a few hundred seeded users make email collisions likely. Documented in `docker-compose.yml`.
- **Pre-existing, untouched:** `tests/Unit` dies partway with `Premature end of PHP process` (a moving target consistent with cumulative exhaustion, not one bad test), and it is what leaks orphan rounds into the dev database. `docker/entrypoint.sh` is unusable from a Windows checkout — LF in git's index, CRLF in the working tree — so it dies with `env: 'bash\r'`. The benchmark service sidesteps it with its own entrypoint.
- This branch is behind `develop` and will need a rebase before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
