### PR TITLE
Fix Wonder over kill bug

### DIFF
--- a/src/Services/Dominion/Actions/WonderActionService.php
+++ b/src/Services/Dominion/Actions/WonderActionService.php
@@ -210,10 +210,15 @@ class WonderActionService
             $dominion->wizard_strength -= 5;
             $dominion->stat_spell_success += 1;
 
-            $damageDealt = $this->wonderCalculator->getCycloneDamage($dominion, $wonder);
+            // Cap damage at wonder health to prevent overkilling
+            $currentPower = $this->wonderCalculator->getCurrentPower($wonder);
+            $damageDealt = min(
+                $this->wonderCalculator->getCycloneDamage($dominion, $wonder),
+                $currentPower
+            );
             $dominion->stat_cyclone_damage += $damageDealt;
 
-            $wonderPower = max(0, $this->wonderCalculator->getCurrentPower($wonder) - $damageDealt);
+            $wonderPower = max(0, $currentPower - $damageDealt);
             $wonder->damage()->create([
                 'realm_id' => $dominion->realm_id,
                 'dominion_id' => $dominion->id,
@@ -353,7 +358,11 @@ class WonderActionService
 
             $damageDealt *= $multiplier;
 
-            $wonderPower = max(0, $this->wonderCalculator->getCurrentPower($wonder) - $damageDealt);
+            // Cap damage at wonder health to prevent overkilling
+            $currentPower = $this->wonderCalculator->getCurrentPower($wonder);
+            $damageDealt = min($damageDealt, $currentPower);
+
+            $wonderPower = max(0, $currentPower - $damageDealt);
             $wonder->damage()->create([
                 'realm_id' => $dominion->realm_id,
                 'dominion_id' => $dominion->id,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Caps recorded damage dealt at the maximum health the wonder has remaining for both attacks and cyclones.

## Motivation and Context
Fixes [Issue #925](https://github.com/OpenDominion/OpenDominion/issues/925)

## How Has This Been Tested?
Fix passed the eye test.  No tests currently exist for the WonderActionService and I'm too lazy to add them for this.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
