### PR TITLE
fix/tech-unlock-badge-when-fully-teched

### DIFF
--- a/app/resources/views/pages/dominion/techs.blade.php
+++ b/app/resources/views/pages/dominion/techs.blade.php
@@ -20,6 +20,8 @@
             return $tech->key !== 'tech_7_5' && !in_array($tech->key, $permanentTechKeys);
         });
 
+        $unlockableTechCount = $techCalculator->getUnlockableTechCount($selectedDominion);
+
         $tempTechCooldownHours = 0;
         if ($currentTempTech) {
             $selectedAt = $currentTempTech->pivot->created_at->startOfHour();
@@ -92,7 +94,7 @@
                         </div>
                     </div>
                     <div class="card-footer">
-                        <button type="submit" class="btn btn-primary" {{ ($techCalculator->getTechCost($selectedDominion) > $selectedDominion->resource_tech || $selectedDominion->isLocked()) ? 'disabled' : null }}>Unlock</button>
+                        <button type="submit" class="btn btn-primary" {{ ($unlockableTechCount < 1 || $selectedDominion->isLocked()) ? 'disabled' : null }}>Unlock</button>
                     </div>
                 </div>
 
@@ -149,7 +151,7 @@
                         </table>
                     </div>
                     <div class="card-footer">
-                        <button type="submit" class="btn btn-primary" {{ ($techCalculator->getTechCost($selectedDominion) > $selectedDominion->resource_tech || $selectedDominion->isLocked()) ? 'disabled' : null }}>Unlock</button>
+                        <button type="submit" class="btn btn-primary" {{ ($unlockableTechCount < 1 || $selectedDominion->isLocked()) ? 'disabled' : null }}>Unlock</button>
                     </div>
                 </div>
             </form>

--- a/src/Calculators/Dominion/Actions/TechCalculator.php
+++ b/src/Calculators/Dominion/Actions/TechCalculator.php
@@ -3,6 +3,7 @@
 namespace OpenDominion\Calculators\Dominion\Actions;
 
 use OpenDominion\Calculators\Dominion\HeroCalculator;
+use OpenDominion\Helpers\TechHelper;
 use OpenDominion\Models\Dominion;
 use OpenDominion\Models\Tech;
 
@@ -11,14 +12,19 @@ class TechCalculator
     /** @var HeroCalculator */
     protected $heroCalculator;
 
+    /** @var TechHelper */
+    protected $techHelper;
+
     /**
      * TechCalculator constructor.
      */
     public function __construct(
-        HeroCalculator $heroCalculator
+        HeroCalculator $heroCalculator,
+        TechHelper $techHelper
     )
     {
         $this->heroCalculator = $heroCalculator;
+        $this->techHelper = $techHelper;
     }
 
     /**
@@ -44,6 +50,49 @@ class TechCalculator
         $techCost = (2.5 * $dominion->highest_land_achieved) + (50 * $permanentTechCount);
 
         return max(3750, round($techCost * $multiplier));
+    }
+
+    /**
+     * Returns the number of techs the Dominion can unlock right now.
+     *
+     * Capped by the number of techs still available to research, so that a
+     * fully teched Dominion is never told it has techs left to unlock.
+     *
+     * @param Dominion $dominion
+     * @return int
+     */
+    public function getUnlockableTechCount(Dominion $dominion): int
+    {
+        $affordableTechCount = rfloor($dominion->resource_tech / $this->getTechCost($dominion));
+
+        if ($affordableTechCount <= 0) {
+            return 0;
+        }
+
+        return min($affordableTechCount, $this->getAvailableTechCount($dominion));
+    }
+
+    /**
+     * Returns the number of techs the Dominion has not unlocked yet and meets
+     * the prerequisites for, regardless of research points.
+     *
+     * @param Dominion $dominion
+     * @return int
+     */
+    public function getAvailableTechCount(Dominion $dominion): int
+    {
+        $unlockedTechKeys = $dominion->techs->filter(function ($tech) {
+            return $tech->pivot->source_id === null;
+        })->pluck('key')->all();
+
+        return $this->techHelper->getTechs($dominion->round->tech_version)
+            ->reject(function ($tech) use ($unlockedTechKeys) {
+                return in_array($tech->key, $unlockedTechKeys);
+            })
+            ->filter(function ($tech) use ($dominion) {
+                return $this->hasPrerequisites($dominion, $tech);
+            })
+            ->count();
     }
 
     /**

--- a/src/Providers/ComposerServiceProvider.php
+++ b/src/Providers/ComposerServiceProvider.php
@@ -88,8 +88,7 @@ class ComposerServiceProvider extends AbstractServiceProvider
 
             // Show icon for techs
             $techCalculator = app(TechCalculator::class);
-            $techCost = $techCalculator->getTechCost($selectedDominion);
-            $unlockableTechCount = rfloor($selectedDominion->resource_tech / $techCost);
+            $unlockableTechCount = $techCalculator->getUnlockableTechCount($selectedDominion);
             $view->with('unlockableTechCount', $unlockableTechCount);
 
             // Show indicator for temporary tech selection (Planar Gates)

--- a/tests/Feature/Dominion/TechUnlockCountTest.php
+++ b/tests/Feature/Dominion/TechUnlockCountTest.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace OpenDominion\Tests\Feature\Dominion;
+
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use OpenDominion\Calculators\Dominion\Actions\TechCalculator;
+use OpenDominion\Models\DominionTech;
+use OpenDominion\Models\Tech;
+use OpenDominion\Tests\AbstractBrowserKitTestCase;
+
+class TechUnlockCountTest extends AbstractBrowserKitTestCase
+{
+    use DatabaseTransactions;
+
+    /** @var \OpenDominion\Models\User */
+    protected $user;
+
+    /** @var \OpenDominion\Models\Round */
+    protected $round;
+
+    /** @var \OpenDominion\Models\Dominion */
+    protected $dominion;
+
+    /** @var TechCalculator */
+    protected $techCalculator;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->user = $this->createAndImpersonateUser();
+        $this->round = $this->createRound();
+        $this->round->update(['tech_version' => 2]);
+        $this->dominion = $this->createAndSelectDominion($this->user, $this->round);
+
+        $this->techCalculator = app(TechCalculator::class);
+    }
+
+    /**
+     * Give the dominion the specified amount of research points.
+     */
+    protected function setResearchPoints(int $amount): void
+    {
+        $this->dominion->resource_tech = $amount;
+        $this->dominion->save();
+    }
+
+    /**
+     * Permanently unlock every tech of the round's tech version.
+     */
+    protected function unlockAllTechs(): void
+    {
+        Tech::where('version', $this->round->tech_version)->get()->each(function ($tech) {
+            DominionTech::create([
+                'dominion_id' => $this->dominion->id,
+                'tech_id' => $tech->id,
+            ]);
+        });
+
+        $this->dominion->load('techs');
+    }
+
+    public function testUnlockableTechCountIsZeroWithoutEnoughResearchPoints()
+    {
+        $this->setResearchPoints($this->techCalculator->getTechCost($this->dominion) - 1);
+
+        $this->assertEquals(0, $this->techCalculator->getUnlockableTechCount($this->dominion));
+    }
+
+    public function testUnlockableTechCountIsBasedOnResearchPoints()
+    {
+        $this->setResearchPoints(3 * $this->techCalculator->getTechCost($this->dominion));
+
+        $availableTechCount = $this->techCalculator->getAvailableTechCount($this->dominion);
+        $this->assertGreaterThan(0, $availableTechCount);
+
+        $this->assertEquals(min(3, $availableTechCount), $this->techCalculator->getUnlockableTechCount($this->dominion));
+    }
+
+    public function testUnlockableTechCountIsZeroWhenFullyTeched()
+    {
+        $this->unlockAllTechs();
+        $this->setResearchPoints(10 * $this->techCalculator->getTechCost($this->dominion));
+
+        $this->assertEquals(0, $this->techCalculator->getAvailableTechCount($this->dominion));
+        $this->assertEquals(0, $this->techCalculator->getUnlockableTechCount($this->dominion));
+    }
+
+    public function testUnlockableTechCountIsCappedByRemainingTechs()
+    {
+        $this->unlockAllTechs();
+
+        // Re-open a single tech for research
+        $lastTech = Tech::where('version', $this->round->tech_version)->get()->last();
+        DominionTech::where('dominion_id', $this->dominion->id)
+            ->where('tech_id', $lastTech->id)
+            ->delete();
+        $this->dominion->load('techs');
+
+        $this->setResearchPoints(10 * $this->techCalculator->getTechCost($this->dominion));
+
+        $this->assertEquals(1, $this->techCalculator->getAvailableTechCount($this->dominion));
+        $this->assertEquals(1, $this->techCalculator->getUnlockableTechCount($this->dominion));
+    }
+}


### PR DESCRIPTION
## Description

The sidebar "Technology" badge now reflects how many techs can *actually* be unlocked, rather than how many the dominion's research points would pay for.

- `TechCalculator::getAvailableTechCount()` — new. Counts techs of the round's tech version that are not permanently unlocked and whose prerequisites are met. A tech held temporarily via Planar Gates still counts as researchable, matching the existing behaviour in `TechActionService::unlock()`.
- `TechCalculator::getUnlockableTechCount()` — new. The affordable count (`resource_tech / techCost`) capped by the available count. `TechHelper` is now injected into the calculator.
- `ComposerServiceProvider` — the `unlockableTechCount` shared with the sidebar now comes from `getUnlockableTechCount()`, so the badge disappears at zero and never shows "2" when only one tech remains.
- `pages/dominion/techs.blade.php` — both Unlock buttons are disabled on the same count instead of on research point cost alone, so a fully teched player can no longer submit a form that has nothing selectable.

## Motivation and Context

Fixes #795.

Once a dominion had unlocked every tech it kept accruing research points, and the badge was computed purely as `rfloor(resource_tech / techCost)`. Every time the threshold was passed the indicator reappeared — and incremented — for the rest of the round, even though the Technology page had nothing left to unlock. Visiting the page did not clear it, because nothing about the page changed the count.

Capping by the number of researchable techs also fixes the related case called out in the issue: with enough research points for two techs but only one left in the tree, the badge now reads "1".

## How Has This Been Tested?

Added `tests/Feature/Dominion/TechUnlockCountTest.php` covering:

- research points below the tech cost → count is 0
- research points for three techs, techs available → count is 3
- all techs unlocked with 10x the tech cost banked → available and unlockable counts are both 0 (the issue's scenario)
- all techs unlocked except one, 10x the tech cost banked → count is 1 (the "2 icon" scenario)

Caveat, please verify before merging: I was unable to execute the suite in my environment — no PHP runtime and no running Docker daemon available, so the tests are written but not yet run. They should be run with `./vendor/bin/phpunit --filter=TechUnlockCountTest`, plus `--filter=TemporaryTechTest` since `TechCalculator`'s constructor signature changed (it is always resolved through the container, so no call sites needed updating).

## Screenshots (if appropriate):

N/A

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.