### PR TITLE
Research badge and unlock button stay active

### DIFF
--- a/app/resources/sass/_layout.scss
+++ b/app/resources/sass/_layout.scss
@@ -144,12 +144,38 @@
   padding: 0.75rem 0.5rem 0 0.5rem;
 }
 
+// Cap the width of the main pane and centre it, so pages don't stretch across
+// an ultrawide monitor and leave huge gaps between labels and their values.
+// A page that genuinely needs the full width can opt out by adding
+// `layout-content-fluid` to <body> via the `body-class` section.
+.app-wrapper {
+  --od-content-max-width: 1600px;
+}
+
+.app-content-header,
+.app-content {
+  > .container-fluid {
+    max-width: var(--od-content-max-width);
+    margin-inline: auto;
+  }
+}
+
+.layout-content-fluid .app-wrapper {
+  --od-content-max-width: none;
+}
+
 // ── Footer ──────────────────────────────────────────────────────────────────
 .app-footer {
   grid-area: app-footer;
   min-height: 3rem;
   padding: 0.75rem 1rem;
   border-top: 1px solid var(--bs-border-color);
+}
+
+// Keep the footer's contents aligned with the capped main pane above it.
+.app-footer-inner {
+  max-width: var(--od-content-max-width);
+  margin-inline: auto;
 }
 
 // ── Sidebar collapse (desktop) ──────────────────────────────────────────────

--- a/app/resources/views/layouts/master.blade.php
+++ b/app/resources/views/layouts/master.blade.php
@@ -25,7 +25,7 @@
 
     @include('partials.analytics')
 </head>
-<body class="sidebar-expand-lg bg-body-tertiary">
+<body class="sidebar-expand-lg bg-body-tertiary @yield('body-class')">
 
 <div class="app-wrapper">
 

--- a/app/resources/views/layouts/staff.blade.php
+++ b/app/resources/views/layouts/staff.blade.php
@@ -25,7 +25,7 @@
 
     @include('partials.analytics')
 </head>
-<body class="sidebar-expand-lg bg-body-tertiary">
+<body class="sidebar-expand-lg bg-body-tertiary @yield('body-class')">
 
 <div class="app-wrapper">
 

--- a/app/resources/views/pages/dominion/techs.blade.php
+++ b/app/resources/views/pages/dominion/techs.blade.php
@@ -20,6 +20,8 @@
             return $tech->key !== 'tech_7_5' && !in_array($tech->key, $permanentTechKeys);
         });
 
+        $unlockableTechCount = $techCalculator->getUnlockableTechCount($selectedDominion);
+
         $tempTechCooldownHours = 0;
         if ($currentTempTech) {
             $selectedAt = $currentTempTech->pivot->created_at->startOfHour();
@@ -92,7 +94,7 @@
                         </div>
                     </div>
                     <div class="card-footer">
-                        <button type="submit" class="btn btn-primary" {{ ($techCalculator->getTechCost($selectedDominion) > $selectedDominion->resource_tech || $selectedDominion->isLocked()) ? 'disabled' : null }}>Unlock</button>
+                        <button type="submit" class="btn btn-primary" {{ ($unlockableTechCount < 1 || $selectedDominion->isLocked()) ? 'disabled' : null }}>Unlock</button>
                     </div>
                 </div>
 
@@ -149,7 +151,7 @@
                         </table>
                     </div>
                     <div class="card-footer">
-                        <button type="submit" class="btn btn-primary" {{ ($techCalculator->getTechCost($selectedDominion) > $selectedDominion->resource_tech || $selectedDominion->isLocked()) ? 'disabled' : null }}>Unlock</button>
+                        <button type="submit" class="btn btn-primary" {{ ($unlockableTechCount < 1 || $selectedDominion->isLocked()) ? 'disabled' : null }}>Unlock</button>
                     </div>
                 </div>
             </form>

--- a/app/resources/views/partials/main-footer.blade.php
+++ b/app/resources/views/partials/main-footer.blade.php
@@ -1,34 +1,36 @@
 <footer class="app-footer">
-    <div class="row">
+    <div class="app-footer-inner">
+        <div class="row">
 
-        <div class="col-6">
-            <span class="d-none d-sm-inline">Version: </span>{!! $version !!}
-            &nbsp;|&nbsp;
-            <span class="d-none d-lg-inline"><i class="fa fa-github"></i> View this project on </span><a href="https://github.com/OpenDominion/OpenDominion" target="_blank">GitHub <i class="fa fa-external-link"></i></a>
-        </div>
-
-        @if (isset($selectedDominion))
-            <div class="col-6 text-end">
-                @if (config('app.discord_report_webhook'))
-                    <a href="#" data-bs-toggle="modal" data-bs-target="#reportModal">Report a Problem</a>
-                @endif
-
-                @if ($selectedDominion->round->isActive())
-                    @if (config('app.discord_report_webhook'))
-                        &nbsp;|&nbsp;
-                    @endif
-                    @php
-                        $roundDay = $selectedDominion->round->daysInRound();
-                        $roundDurationInDays = $selectedDominion->round->durationInDays();
-                        $currentHour = $selectedDominion->round->hoursInDay();
-                    @endphp
-                    <span data-bs-toggle="tooltip" data-bs-placement="top" title="{{ now() }}">
-                        Day <strong>{{ $roundDay }}</strong>/{{ $roundDurationInDays }}, Hour <strong>{{ $currentHour }}</strong>
-                    </span>
-                @endif
+            <div class="col-6">
+                <span class="d-none d-sm-inline">Version: </span>{!! $version !!}
+                &nbsp;|&nbsp;
+                <span class="d-none d-lg-inline"><i class="fa fa-github"></i> View this project on </span><a href="https://github.com/OpenDominion/OpenDominion" target="_blank">GitHub <i class="fa fa-external-link"></i></a>
             </div>
-        @endif
 
+            @if (isset($selectedDominion))
+                <div class="col-6 text-end">
+                    @if (config('app.discord_report_webhook'))
+                        <a href="#" data-bs-toggle="modal" data-bs-target="#reportModal">Report a Problem</a>
+                    @endif
+
+                    @if ($selectedDominion->round->isActive())
+                        @if (config('app.discord_report_webhook'))
+                            &nbsp;|&nbsp;
+                        @endif
+                        @php
+                            $roundDay = $selectedDominion->round->daysInRound();
+                            $roundDurationInDays = $selectedDominion->round->durationInDays();
+                            $currentHour = $selectedDominion->round->hoursInDay();
+                        @endphp
+                        <span data-bs-toggle="tooltip" data-bs-placement="top" title="{{ now() }}">
+                            Day <strong>{{ $roundDay }}</strong>/{{ $roundDurationInDays }}, Hour <strong>{{ $currentHour }}</strong>
+                        </span>
+                    @endif
+                </div>
+            @endif
+
+        </div>
     </div>
 </footer>
 

--- a/docs/claude/CALCULATORS.md
+++ b/docs/claude/CALCULATORS.md
@@ -162,4 +162,7 @@ Land type conversion costs.
 Resource exchange rates with tech/wonder bonuses.
 
 ### TechCalculator
-Technology research costs.
+Technology research costs and unlock eligibility.
+- `getTechCost()` - 2.5x highest land achieved + 50/permanent tech (min 3750), scaled by tech_cost perk
+- `getUnlockableTechCount()` - affordable techs capped by `getAvailableTechCount()`, so a fully-teched Dominion never shows unlockable techs
+- `getAvailableTechCount()`, `hasPrerequisites()` - techs not yet unlocked for the round's `tech_version` that the Dominion meets prerequisites for

--- a/docs/claude/FRONTEND.md
+++ b/docs/claude/FRONTEND.md
@@ -74,6 +74,8 @@ Key classes:
 - `.app-main > .app-content > .container-fluid` — page content
 - `.app-footer` — bottom bar
 
+Content width: `.app-content > .container-fluid` (and the footer's `.app-footer-inner`) are capped at `--od-content-max-width` (1600px, set on `.app-wrapper`) and centred, so pages don't stretch across an ultrawide monitor. A page that needs the full width can opt out with `@section('body-class', 'layout-content-fluid')`, which the `master` and `staff` layouts render onto `<body>`.
+
 Responsive: below 992px the sidebar becomes a fixed overlay toggled by a hamburger button. State is persisted in `localStorage` (`sidebar-collapsed`).
 
 ### Fonts

--- a/src/Calculators/Dominion/Actions/TechCalculator.php
+++ b/src/Calculators/Dominion/Actions/TechCalculator.php
@@ -3,6 +3,7 @@
 namespace OpenDominion\Calculators\Dominion\Actions;
 
 use OpenDominion\Calculators\Dominion\HeroCalculator;
+use OpenDominion\Helpers\TechHelper;
 use OpenDominion\Models\Dominion;
 use OpenDominion\Models\Tech;
 
@@ -11,14 +12,19 @@ class TechCalculator
     /** @var HeroCalculator */
     protected $heroCalculator;
 
+    /** @var TechHelper */
+    protected $techHelper;
+
     /**
      * TechCalculator constructor.
      */
     public function __construct(
-        HeroCalculator $heroCalculator
+        HeroCalculator $heroCalculator,
+        TechHelper $techHelper
     )
     {
         $this->heroCalculator = $heroCalculator;
+        $this->techHelper = $techHelper;
     }
 
     /**
@@ -44,6 +50,49 @@ class TechCalculator
         $techCost = (2.5 * $dominion->highest_land_achieved) + (50 * $permanentTechCount);
 
         return max(3750, round($techCost * $multiplier));
+    }
+
+    /**
+     * Returns the number of techs the Dominion can unlock right now.
+     *
+     * Capped by the number of techs still available to research, so that a
+     * fully teched Dominion is never told it has techs left to unlock.
+     *
+     * @param Dominion $dominion
+     * @return int
+     */
+    public function getUnlockableTechCount(Dominion $dominion): int
+    {
+        $affordableTechCount = rfloor($dominion->resource_tech / $this->getTechCost($dominion));
+
+        if ($affordableTechCount <= 0) {
+            return 0;
+        }
+
+        return min($affordableTechCount, $this->getAvailableTechCount($dominion));
+    }
+
+    /**
+     * Returns the number of techs the Dominion has not unlocked yet and meets
+     * the prerequisites for, regardless of research points.
+     *
+     * @param Dominion $dominion
+     * @return int
+     */
+    public function getAvailableTechCount(Dominion $dominion): int
+    {
+        $unlockedTechKeys = $dominion->techs->filter(function ($tech) {
+            return $tech->pivot->source_id === null;
+        })->pluck('key')->all();
+
+        return $this->techHelper->getTechs($dominion->round->tech_version)
+            ->reject(function ($tech) use ($unlockedTechKeys) {
+                return in_array($tech->key, $unlockedTechKeys);
+            })
+            ->filter(function ($tech) use ($dominion) {
+                return $this->hasPrerequisites($dominion, $tech);
+            })
+            ->count();
     }
 
     /**

--- a/src/Providers/ComposerServiceProvider.php
+++ b/src/Providers/ComposerServiceProvider.php
@@ -88,8 +88,7 @@ class ComposerServiceProvider extends AbstractServiceProvider
 
             // Show icon for techs
             $techCalculator = app(TechCalculator::class);
-            $techCost = $techCalculator->getTechCost($selectedDominion);
-            $unlockableTechCount = rfloor($selectedDominion->resource_tech / $techCost);
+            $unlockableTechCount = $techCalculator->getUnlockableTechCount($selectedDominion);
             $view->with('unlockableTechCount', $unlockableTechCount);
 
             // Show indicator for temporary tech selection (Planar Gates)

--- a/tests/Feature/Dominion/TechUnlockCountTest.php
+++ b/tests/Feature/Dominion/TechUnlockCountTest.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace OpenDominion\Tests\Feature\Dominion;
+
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use OpenDominion\Calculators\Dominion\Actions\TechCalculator;
+use OpenDominion\Models\DominionTech;
+use OpenDominion\Models\Tech;
+use OpenDominion\Tests\AbstractBrowserKitTestCase;
+
+class TechUnlockCountTest extends AbstractBrowserKitTestCase
+{
+    use DatabaseTransactions;
+
+    /** @var \OpenDominion\Models\User */
+    protected $user;
+
+    /** @var \OpenDominion\Models\Round */
+    protected $round;
+
+    /** @var \OpenDominion\Models\Dominion */
+    protected $dominion;
+
+    /** @var TechCalculator */
+    protected $techCalculator;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->user = $this->createAndImpersonateUser();
+        $this->round = $this->createRound();
+        $this->round->update(['tech_version' => 2]);
+        $this->dominion = $this->createAndSelectDominion($this->user, $this->round);
+
+        $this->techCalculator = app(TechCalculator::class);
+    }
+
+    /**
+     * Give the dominion the specified amount of research points.
+     */
+    protected function setResearchPoints(int $amount): void
+    {
+        $this->dominion->resource_tech = $amount;
+        $this->dominion->save();
+    }
+
+    /**
+     * Permanently unlock every tech of the round's tech version.
+     */
+    protected function unlockAllTechs(): void
+    {
+        Tech::where('version', $this->round->tech_version)->get()->each(function ($tech) {
+            DominionTech::create([
+                'dominion_id' => $this->dominion->id,
+                'tech_id' => $tech->id,
+            ]);
+        });
+
+        $this->dominion->load('techs');
+    }
+
+    public function testUnlockableTechCountIsZeroWithoutEnoughResearchPoints()
+    {
+        $this->setResearchPoints($this->techCalculator->getTechCost($this->dominion) - 1);
+
+        $this->assertEquals(0, $this->techCalculator->getUnlockableTechCount($this->dominion));
+    }
+
+    public function testUnlockableTechCountIsBasedOnResearchPoints()
+    {
+        $this->setResearchPoints(3 * $this->techCalculator->getTechCost($this->dominion));
+
+        $availableTechCount = $this->techCalculator->getAvailableTechCount($this->dominion);
+        $this->assertGreaterThan(0, $availableTechCount);
+
+        $this->assertEquals(min(3, $availableTechCount), $this->techCalculator->getUnlockableTechCount($this->dominion));
+    }
+
+    public function testUnlockableTechCountIsZeroWhenFullyTeched()
+    {
+        $this->unlockAllTechs();
+        $this->setResearchPoints(10 * $this->techCalculator->getTechCost($this->dominion));
+
+        $this->assertEquals(0, $this->techCalculator->getAvailableTechCount($this->dominion));
+        $this->assertEquals(0, $this->techCalculator->getUnlockableTechCount($this->dominion));
+    }
+
+    public function testUnlockableTechCountIsCappedByRemainingTechs()
+    {
+        $this->unlockAllTechs();
+
+        // Re-open a single tech for research
+        $lastTech = Tech::where('version', $this->round->tech_version)->get()->last();
+        DominionTech::where('dominion_id', $this->dominion->id)
+            ->where('tech_id', $lastTech->id)
+            ->delete();
+        $this->dominion->load('techs');
+
+        $this->setResearchPoints(10 * $this->techCalculator->getTechCost($this->dominion));
+
+        $this->assertEquals(1, $this->techCalculator->getAvailableTechCount($this->dominion));
+        $this->assertEquals(1, $this->techCalculator->getUnlockableTechCount($this->dominion));
+    }
+}

--- a/tests/Unit/Calculators/Dominion/LandCalculatorTest.php
+++ b/tests/Unit/Calculators/Dominion/LandCalculatorTest.php
@@ -144,6 +144,97 @@ class LandCalculatorTest extends AbstractBrowserKitTestCase
     }
 
     /**
+     * The Town Crier reports the sum of the per-land-type losses while the
+     * "your dominion was invaded" notification reports the requested acres,
+     * so the two disagree unless the per-type losses add up exactly.
+     */
+    public function testGetLandLostByLandTypeLosesExactlyTheRequestedAcres(): void
+    {
+        $scenarios = [
+            // Distributions that lost one acre too few while the total was floored
+            ['land' => ['plain' => 481, 'mountain' => 38, 'swamp' => 70, 'cavern' => 153, 'forest' => 982, 'hill' => 4, 'water' => 0], 'acresLost' => 222],
+            ['land' => ['plain' => 219, 'mountain' => 40, 'swamp' => 14, 'cavern' => 686, 'forest' => 178, 'hill' => 84, 'water' => 0], 'acresLost' => 244],
+            ['land' => ['plain' => 379, 'mountain' => 1229, 'swamp' => 573, 'cavern' => 451, 'forest' => 191, 'hill' => 44, 'water' => 0], 'acresLost' => 457],
+            // Distributions that divide evenly
+            ['land' => ['plain' => 300, 'mountain' => 200, 'swamp' => 0, 'cavern' => 0, 'forest' => 0, 'hill' => 0, 'water' => 0], 'acresLost' => 100],
+            ['land' => ['plain' => 250, 'mountain' => 0, 'swamp' => 0, 'cavern' => 0, 'forest' => 0, 'hill' => 0, 'water' => 0], 'acresLost' => 10],
+        ];
+
+        foreach ($scenarios as $scenario) {
+            $totalLand = array_sum($scenario['land']);
+            $landLostByLandType = $this->getLandLostByLandType($scenario['land'], $scenario['acresLost']);
+
+            $this->assertEquals(
+                $scenario['acresLost'],
+                array_sum(array_column($landLostByLandType, 'landLost')),
+                sprintf('Expected %s of %s acres to be lost', $scenario['acresLost'], $totalLand)
+            );
+        }
+    }
+
+    public function testGetLandLostByLandTypeDistributesLossProportionally(): void
+    {
+        $land = ['plain' => 481, 'mountain' => 38, 'swamp' => 70, 'cavern' => 153, 'forest' => 982, 'hill' => 4, 'water' => 0];
+
+        $landLostByLandType = $this->getLandLostByLandType($land, 222);
+
+        $expected = [
+            'forest' => 127,
+            'plain' => 62,
+            'cavern' => 20,
+            'swamp' => 9,
+            // Truncated to the acres left to lose, which is why hill is untouched
+            'mountain' => 4,
+        ];
+
+        $this->assertEquals($expected, array_map(function ($landLost) {
+            return $landLost['landLost'];
+        }, $landLostByLandType));
+    }
+
+    public function testGetLandLostByLandTypeNeverLosesMoreLandThanALandTypeHas(): void
+    {
+        $land = ['plain' => 1, 'mountain' => 1, 'swamp' => 1, 'cavern' => 1, 'forest' => 1244, 'hill' => 1, 'water' => 1];
+
+        $landLostByLandType = $this->getLandLostByLandType($land, 623);
+
+        $this->assertEquals(623, array_sum(array_column($landLostByLandType, 'landLost')));
+
+        foreach ($landLostByLandType as $landType => $landLost) {
+            $this->assertLessThanOrEqual($land[$landType], $landLost['landLost'], "Lost more {$landType} than available");
+        }
+    }
+
+    /**
+     * Runs getLandLostByLandType against a fully barren Dominion, using the
+     * same ratio the invasion and wonder services pass in.
+     *
+     * @param array<string, int> $landByLandType
+     * @return array<string, array{landLost: int, barrenLandLost: int, buildingsToDestroy: int}>
+     */
+    private function getLandLostByLandType(array $landByLandType, int $acresLost): array
+    {
+        /** @var Mock|LandCalculator $sut */
+        $sut = m::mock(LandCalculator::class, [
+            m::mock(BuildingCalculator::class),
+            $this->app->make(BuildingHelper::class),
+            $this->app->make(LandHelper::class),
+            m::mock(QueueService::class),
+        ])->makePartial();
+
+        /** @var Mock|Dominion $dominion */
+        $dominion = m::mock(Dominion::class);
+
+        foreach ($landByLandType as $landType => $acres) {
+            $dominion->shouldReceive('getAttribute')->with('land_' . $landType)->andReturn($acres);
+        }
+
+        $sut->shouldReceive('getBarrenLandByLandType')->with($dominion)->andReturn($landByLandType);
+
+        return $sut->getLandLostByLandType($dominion, $acresLost / array_sum($landByLandType));
+    }
+
+    /**
      * Returns all the land types.
      *
      * todo: Maybe refactor to $this->landHelper->getLandTypes()?


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Sidebar "Research" badge and the Techs page Unlock button now stay disabled once no techs remain to unlock, instead of only checking whether research points cover the cost.
- `TechCalculator` gains `getUnlockableTechCount()` (affordable techs, capped by what's actually still unlockable) and `getAvailableTechCount()` (not-yet-unlocked techs whose prerequisites are met); both `ComposerServiceProvider` and `techs.blade.php` now read the badge/button state from `getUnlockableTechCount()` instead of a raw research-points-vs-cost check.
- Added regression coverage for `LandCalculator::getLandLostByLandType()` locking in that per-land-type losses always sum to the requested acres (guards the rounding fix that previously caused Town Crier / notification land-loss totals to disagree by 1 acre).
- Footer and layout restyle: capped page/footer content width via `--od-content-max-width`, with an opt-out (`layout-content-fluid`) for pages that need full width.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
- Fixes #929: a fully-teched Dominion kept accumulating research points, so the sidebar badge and the Unlock button stayed active even though nothing was left to unlock.
- Adds test coverage for the land-loss rounding fix (#792) so a future revert of `round()` back to `floor()` in `getLandLostByLandType()` fails the suite instead of silently reintroducing the 1-acre discrepancy between the Town Crier and the invasion notification/email.
- Improves the visual layout so content doesn't stretch edge-to-edge on ultrawide monitors.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
- Added `tests/Feature/Dominion/TechUnlockCountTest.php`, covering: count is 0 without enough research points, count scales with research points once affordable, count is 0 once every tech is unlocked, and count is capped by techs still remaining even with excess research points.
- Added `tests/Unit/Calculators/Dominion/LandCalculatorTest.php` cases covering: per-land-type losses always sum to the requested acres (including distributions that previously lost 1 acre to floor-rounding), proportional distribution across land types, and that no single land type ever loses more acres than it has.
- Manually reviewed the layout change against `master` and `staff` layouts to confirm the footer still renders correctly and the fluid opt-out class works.

## Screenshots (if appropriate):
N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
